### PR TITLE
Improve normalizer dummy

### DIFF
--- a/src/normalizer/dummy_example.rs
+++ b/src/normalizer/dummy_example.rs
@@ -17,7 +17,7 @@ impl Normalizer for DummyNormalizer {
     // Creates an iterator over the normalized version of the provided token.
     fn normalize<'o>(&self, mut token: Token<'o>) -> Box<dyn Iterator<Item = Token<'o>> + 'o> {
         // lowercase the provided token lemma.
-        token.lemma = (*token.lemma).lowercase();
+        token.lemma = Cow::Owned(token.lemma().to_lowercase());
 
         // Create an iterator over the normalized token.
         Box::new(Some(token).into_iter())
@@ -31,6 +31,7 @@ impl Normalizer for DummyNormalizer {
 }
 
 // Include the newly implemented Normalizer in the tokenization pipeline:
+//     - change the name of the file `dummy_example.rs` to `dummy.rs`
 //     - import module by adding `mod dummy;` (filename) in `normalizer/mod.rs`
 //     - Add Normalizer in `NORMALIZERS` in `normalizer/mod.rs`
 //     - check if it didn't break any test or benhchmark
@@ -95,7 +96,7 @@ mod test {
                 ..Default::default()
             },
             Token {
-                lemma: Owned("паскалькейс".to_string()),
+                lemma: Owned("paskal'keis".to_string()),
                 char_end: 11,
                 byte_end: 22,
                 script: Script::Latin,


### PR DESCRIPTION
The normalizer dummy had the following issue:

- The normalization of the lemma into lowercase did not work
- The last test was failing
- The documentation was missing a step


Suggestion:

- The normalizer dummy should show an example where a token is separated into multiple tokens. ([rough example here](https://github.com/bidoubiwa/charabia/pull/1))
- Visual on the tests were a bit hard to read. Maybe a pretty error format would be nice.
- Lastly but I think this has already been raised but it could be cool to subscribe to the normalizer from the outside instead of having to add it manually into `mod.rs`
