### PR TITLE
Reimplement Japanese segmenter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ once_cell = "1.5.2"
 slice-group-by = "0.3.0"
 unicode-segmentation = "1.6.0"
 whatlang = "0.13.0"
+lindera = { version = "0.13.5", features = ["ipadic", "unidic"], optional = true }
+lindera-core = { version = "0.13.4", optional = true }
 
 [features]
-default = ["chinese", "hebrew"]
+default = ["chinese", "hebrew", "japanese"]
 
 # allow chinese specialized tokenization
 chinese = ["dep:character_converter", "dep:jieba-rs"]
@@ -30,6 +32,8 @@ chinese = ["dep:character_converter", "dep:jieba-rs"]
 # allow hebrew specialized tokenization
 hebrew = []
 
+# allow japanese specialized tokenization
+japanese = ["dep:lindera", "dep:lindera-core"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/normalizer/chinese.rs
+++ b/src/normalizer/chinese.rs
@@ -20,8 +20,8 @@ impl Normalizer for ChineseNormalizer {
         Box::new(Some(token).into_iter())
     }
 
-    fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {
-        script == Script::Cj
+    fn should_normalize(&self, script: Script, language: Option<Language>) -> bool {
+        script == Script::Cj && language == Some(Language::Cmn)
     }
 }
 
@@ -39,6 +39,7 @@ mod test {
                 char_end: 2,
                 byte_end: 6,
                 script: Script::Cj,
+                language: Some(Language::Cmn),
                 ..Default::default()
             },
             Token {
@@ -46,6 +47,7 @@ mod test {
                 char_end: 4,
                 byte_end: 12,
                 script: Script::Cj,
+                language: Some(Language::Cmn),
                 ..Default::default()
             },
         ]
@@ -60,6 +62,7 @@ mod test {
                 char_end: 2,
                 byte_end: 6,
                 script: Script::Cj,
+                language: Some(Language::Cmn),
                 ..Default::default()
             },
             Token {
@@ -68,6 +71,7 @@ mod test {
                 char_end: 4,
                 byte_end: 12,
                 script: Script::Cj,
+                language: Some(Language::Cmn),
                 ..Default::default()
             },
         ]
@@ -81,6 +85,7 @@ mod test {
                 char_end: 2,
                 byte_end: 6,
                 script: Script::Cj,
+                language: Some(Language::Cmn),
                 ..Default::default()
             },
             Token {
@@ -88,6 +93,7 @@ mod test {
                 char_end: 4,
                 byte_end: 12,
                 script: Script::Cj,
+                language: Some(Language::Cmn),
                 ..Default::default()
             },
         ]

--- a/src/normalizer/chinese.rs
+++ b/src/normalizer/chinese.rs
@@ -21,7 +21,7 @@ impl Normalizer for ChineseNormalizer {
     }
 
     fn should_normalize(&self, script: Script, language: Option<Language>) -> bool {
-        script == Script::Cj && language == Some(Language::Cmn)
+        script == Script::Cj && matches!(language, None | Some(Language::Cmn))
     }
 }
 

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -1,0 +1,36 @@
+use crate::segmenter::Segmenter;
+use lindera::tokenizer::{Tokenizer as LinderaTokenizer, TokenizerConfig};
+use lindera_core::viterbi::{Mode, Penalty};
+use once_cell::sync::Lazy;
+
+/// Japanese specialized [`Segmenter`].
+///
+/// This Segmenter uses lindera internally to segment the provided text.
+pub struct JapaneseSegmenter;
+
+static LINDERA: Lazy<LinderaTokenizer> = Lazy::new(|| {
+    let config =
+        TokenizerConfig { mode: Mode::Decompose(Penalty::default()), ..TokenizerConfig::default() };
+    LinderaTokenizer::with_config(config).unwrap()
+});
+
+impl Segmenter for JapaneseSegmenter {
+    fn segment_str<'o>(&self, to_segment: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
+        let segment_iterator = LINDERA.tokenize_str(to_segment).map(|vec| vec.into_iter()).unwrap();
+        Box::new(segment_iterator)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::segmenter::test::test_segmenter;
+
+    const TEXT: &str = "関西国際空港限定トートバッグ すもももももももものうち";
+
+    const SEGMENTED: &[&str] = &["関西", "国際", "空港", "限定", "トートバッグ", " ", "すもも", "も", "もも", "も", "もも", "の", "うち"];
+
+    const TOKENIZED: &[&str] = &["関西", "国际", "空港", "限定", "トートバッグ", " ", "すもも", "も", "もも", "も", "もも", "の", "うち"];
+
+    // Macro that run several tests on the Segmenter.
+    test_segmenter!(JapaneseSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Cj, Language::Jpn);
+}

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -29,7 +29,7 @@ mod test {
 
     const SEGMENTED: &[&str] = &["関西", "国際", "空港", "限定", "トートバッグ", " ", "すもも", "も", "もも", "も", "もも", "の", "うち"];
 
-    const TOKENIZED: &[&str] = &["関西", "国际", "空港", "限定", "トートバッグ", " ", "すもも", "も", "もも", "も", "もも", "の", "うち"];
+    const TOKENIZED: &[&str] = SEGMENTED;
 
     // Macro that run several tests on the Segmenter.
     test_segmenter!(JapaneseSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Cj, Language::Jpn);

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -16,8 +16,8 @@ static LINDERA: Lazy<LinderaTokenizer> = Lazy::new(|| {
 
 impl Segmenter for JapaneseSegmenter {
     fn segment_str<'o>(&self, to_segment: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
-        let segment_iterator = LINDERA.tokenize_str(to_segment).map(|vec| vec.into_iter()).unwrap();
-        Box::new(segment_iterator)
+        let segment_iterator = LINDERA.tokenize_str(to_segment).unwrap();
+        Box::new(segment_iterator.into_iter())
     }
 }
 

--- a/src/segmenter/mod.rs
+++ b/src/segmenter/mod.rs
@@ -43,7 +43,7 @@ pub static SEGMENTERS: Lazy<HashMap<(Script, Language), Box<dyn Segmenter>>> = L
         // hebrew segmenter
         #[cfg(feature = "hebrew")]
         ((Script::Hebrew, Language::Heb), Box::new(HebrewSegmenter) as Box<dyn Segmenter>),
-
+        // japanese segmenter
         #[cfg(feature = "japanese")]
         ((Script::Cj, Language::Jpn), Box::new(JapaneseSegmenter) as Box<dyn Segmenter>),
     ]

--- a/src/segmenter/mod.rs
+++ b/src/segmenter/mod.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 pub use chinese::ChineseSegmenter;
 #[cfg(feature = "hebrew")]
 pub use hebrew::HebrewSegmenter;
+#[cfg(feature = "japanese")]
+pub use japanese::JapaneseSegmenter;
 pub use latin::LatinSegmenter;
 use once_cell::sync::Lazy;
 use slice_group_by::StrGroupBy;
@@ -16,6 +18,8 @@ use crate::token::Token;
 mod chinese;
 #[cfg(feature = "hebrew")]
 mod hebrew;
+#[cfg(feature = "japanese")]
+mod japanese;
 mod latin;
 
 /// List of used [`Segmenter`]s linked to their corresponding [`Script`] and [`Language`].
@@ -39,6 +43,9 @@ pub static SEGMENTERS: Lazy<HashMap<(Script, Language), Box<dyn Segmenter>>> = L
         // hebrew segmenter
         #[cfg(feature = "hebrew")]
         ((Script::Hebrew, Language::Heb), Box::new(HebrewSegmenter) as Box<dyn Segmenter>),
+
+        #[cfg(feature = "japanese")]
+        ((Script::Cj, Language::Jpn), Box::new(JapaneseSegmenter) as Box<dyn Segmenter>),
     ]
     .into_iter()
     .collect()
@@ -265,6 +272,7 @@ Check if the tested segmenter is assigned to the good Script/Language in `SEGMEN
             fn tokenize() {
                 let tokens: Vec<_> = $text.tokenize().collect();
                 let tokenized_text: Vec<_> = tokens.iter().map(|t| t.lemma()).collect();
+
                 assert_eq!(&tokenized_text[..], $tokenized, r#"
 Global tokenize() function didn't tokenize the text as expected.
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #89 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## Notes

* This PR adds a `japanese` feature flag which depends on `lindera` and `lindera-core`. These are the crates performing the actual segmenting. The two Japanese dictionary features of `lindera` are used. I have not checked whether both are strictly necessary.
* I have added only one unit test. The benchmarks seemed to already include Japanese text, so I assumed that there was no need to add another one.
* The existing Chinese normaliser was previously triggered on `script ==  Cj`, which meant it was also triggered on Japanese text. I have made it stricter to avoid normalising Japanese text. Now it only triggers when the language is known as `Cmn`.
* `lindera`'s `tokenize_str` method returns a `Result`. It is not clear to me on what conditions this method fails. A previous implementation of the Japanese segmenter on this repo `unwrap`ed the result.  I have done the same thing, but have low confidence on the correctness of that approach.
* Japanese compounded words are decomposed by using the following configuration:
```rust
TokenizerConfig { mode: Mode::Decompose(Penalty::default()), ..TokenizerConfig::default() }
```
* I have tried to avoid initialising `Lindera`every time by storing it in a static `Lazy`, as recommended in the dummy example.

