### PR TITLE
Fix typo in docstring

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -114,7 +114,7 @@ impl Token<'_> {
     ///
     /// chars are counted in the pre-processed string (just before normalizing).
     /// For example, consider the string "Go💼od" which gets normalized to "gobriefcase od".
-    /// `num_chars_from_bytes(11)` for this token will return `(3, 6)` - the number of `(characters, bytes)` in
+    /// `original_lengths(11)` for this token will return `(3, 6)` - the number of `(characters, bytes)` in
     /// the original string for 11 bytes in the normalized string.
     ///
     /// If the `char_map` hasn't been initialized (it is None), usually done

--- a/src/token.rs
+++ b/src/token.rs
@@ -115,6 +115,7 @@ impl Token<'_> {
     /// chars are counted in the pre-processed string (just before normalizing).
     /// For example, consider the string "léopard" which gets normalized to "leopard".
     /// `original_lengths(3)` for this token will return `(3, 4)` - the number of `(characters, bytes)` in
+    /// the original string for 3 bytes in the normalized string.
     ///
     /// If the `char_map` hasn't been initialized (it is None), usually done
     /// by the de-unicoder, it counts the number of `(characters, bytes)` in self.lemma

--- a/src/token.rs
+++ b/src/token.rs
@@ -113,9 +113,8 @@ impl Token<'_> {
     /// token.
     ///
     /// chars are counted in the pre-processed string (just before normalizing).
-    /// For example, consider the string "Go💼od" which gets normalized to "gobriefcase od".
-    /// `original_lengths(11)` for this token will return `(3, 6)` - the number of `(characters, bytes)` in
-    /// the original string for 11 bytes in the normalized string.
+    /// For example, consider the string "léopard" which gets normalized to "leopard".
+    /// `original_lengths(3)` for this token will return `(3, 4)` - the number of `(characters, bytes)` in
     ///
     /// If the `char_map` hasn't been initialized (it is None), usually done
     /// by the de-unicoder, it counts the number of `(characters, bytes)` in self.lemma


### PR DESCRIPTION
This is just a tiny change but while reading the code I noticed that in the docstring of the [`original_lengths`](https://github.com/meilisearch/charabia/blob/1dcaf3cd872d36ad66be41368ab2a97892980a90/src/token.rs#L128) method, the example still uses the old name `num_chars_from_bytes`.