### PR TITLE
Update Hebrew segmenter link to unicode-segmentation instead of Jieba

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Charabia provides a simple API to segment, normalize, or tokenize (segment + nor
 |---------------------|-------------------------------------------------------------------------------|---------------------------|-------------------|---|
 | **Latin** - **Any** | ✅ [unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation) | ✅ lowercase + deunicode            | 🟨 ~12MiB/sec    | 🟧 ~5MiB/sec    |
 | **Chinese** - **CMN** 🇨🇳 | ✅ [jieba](https://github.com/messense/jieba-rs) | ✅ traditional-to-simplified conversion | 🟨 ~9MiB/sec    | 🟧 ~4MiB/sec    |
-| **Hebrew** 🇮🇱 | ✅ [unicode-segmentation](https://github.com/messense/jieba-rs) | ✅ diacritics removal  | 🟩 ~21MiB/sec    | 🟨 ~9MiB/sec    |
+| **Hebrew** 🇮🇱 | ✅ [unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation) | ✅ diacritics removal  | 🟩 ~21MiB/sec    | 🟨 ~9MiB/sec    |
 | **Japanese** 🇯🇵 | ✅ [lindera](https://github.com/lindera-morphology/lindera) | ❌ | 🟧 ~3MiB/sec    | 🟧 ~3MiB/sec    |
 
 We aim to provide global language support, and your feedback helps us [move closer to that goal](https://docs.meilisearch.com/learn/advanced/language.html#improving-our-language-support). If you notice inconsistencies in your search results or the way your documents are processed, please open an issue on our [GitHub repository](https://github.com/meilisearch/charabia/issues/new/choose).


### PR DESCRIPTION
Update Hebrew segmenter link to unicode-segmentation instead of Jieba

fix #107
