### PR TITLE
Deactivate lowercase normalizer when script doesn't contain case modifiers

### DIFF
--- a/src/normalizer/lowercase.rs
+++ b/src/normalizer/lowercase.rs
@@ -25,8 +25,9 @@ impl Normalizer for LowercaseNormalizer {
         Box::new(Some(token).into_iter())
     }
 
-    fn should_normalize(&self, _script: Script, _language: Option<Language>) -> bool {
-        true
+    fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {
+        // https://en.wikipedia.org/wiki/Letter_case#Capitalisation
+        matches!(script, Script::Latin | Script::Cyrillic | Script::Greek | Script::Georgian)
     }
 }
 


### PR DESCRIPTION
# Pull Request

Deactivate lowercase normalizer when the script doesn't contain case modifiers like:
- Hebrew,  ~10% gain
- Thai,  ~7% gain
- Chinese,  ~5% gain

## raw performances diff

```
Gnuplot not found, using plotters backend
tokenize/132/Cj/Cmn     time:   [14.244 us 14.259 us 14.274 us]
                        change: [-4.7991% -4.5840% -4.3744%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  3 (3.00%) high severe
tokenize/132/Cj/Jpn     time:   [24.029 us 24.039 us 24.050 us]
                        change: [-2.8052% -2.6003% -2.3899%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
tokenize/132/Latin/Eng  time:   [12.859 us 12.867 us 12.875 us]
                        change: [-1.3026% -1.0725% -0.8310%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
tokenize/132/Latin/Fra  time:   [12.154 us 12.165 us 12.181 us]
                        change: [-0.8073% -0.5689% -0.3236%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
tokenize/132/Hebrew/Heb time:   [6.0572 us 6.0621 us 6.0679 us]
                        change: [-10.240% -10.059% -9.8775%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe
tokenize/132/Thai/Tha   time:   [5.0117 us 5.0189 us 5.0283 us]
                        change: [-7.9867% -7.7988% -7.6102%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
tokenize/363/Cj/Cmn     time:   [37.644 us 37.664 us 37.685 us]
                        change: [-5.3287% -5.1291% -4.9451%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
tokenize/364/Cj/Jpn     time:   [71.248 us 71.309 us 71.399 us]
                        change: [-1.1275% -0.9053% -0.6718%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe
tokenize/363/Latin/Eng  time:   [30.701 us 30.723 us 30.756 us]
                        change: [-1.0230% -0.8040% -0.5777%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
tokenize/363/Latin/Fra  time:   [30.899 us 30.926 us 30.973 us]
                        change: [-1.3080% -1.0779% -0.8216%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  6 (6.00%) high severe
tokenize/365/Hebrew/Heb time:   [15.962 us 15.977 us 15.994 us]
                        change: [-10.705% -10.508% -10.318%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
tokenize/366/Thai/Tha   time:   [11.069 us 11.080 us 11.093 us]
                        change: [-9.0065% -8.8497% -8.6945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
```