### PR TITLE
Add dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions only
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - 'skip changelog'
+      - 'dependencies'
+    rebase-strategy: disabled


### PR DESCRIPTION
Same as we added in Meilisearch. Only runs once a month. 5 PRs maximum.
https://github.com/meilisearch/meilisearch/blob/main/.github/dependabot.yml