### PR TITLE
Upgrade ubuntu-18.04 to 20.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Rust project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   tests:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Ubuntu-18.04 is going to be deprecated by GitHub
https://github.com/actions/runner-images/issues/6002

Also, using the same ubuntu version in for the tests and for publishing the binary