### PR TITLE
Upgrade lindera to 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1.5.2"
 slice-group-by = "0.3.0"
 unicode-segmentation = "1.6.0"
 whatlang = "0.13.0"
-lindera = { version = "=0.14.0", features = ["ipadic"], optional = true }
+lindera = { version = "=0.16.0", features = ["ipadic"], optional = true }
 
 
 [features]

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -16,8 +16,8 @@ static LINDERA: Lazy<Tokenizer> = Lazy::new(|| {
 
 impl Segmenter for JapaneseSegmenter {
     fn segment_str<'o>(&self, to_segment: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
-        let segment_iterator = LINDERA.tokenize_str(to_segment).unwrap();
-        Box::new(segment_iterator.into_iter())
+        let segment_iterator = LINDERA.tokenize(to_segment).unwrap();
+        Box::new(segment_iterator.into_iter().map(|token| token.text))
     }
 }
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Update Lindera to 0.16.0,  to improve Japanese tokenization performance.
Please see [related PR](https://github.com/lindera-morphology/lindera/pull/211).

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Have you read the contributing guidelines?

## Benchmark results
- segment/132/Cj/Jpn
![Screenshot 2022-09-12 124755](https://user-images.githubusercontent.com/970948/189570447-62918e1d-1184-4c4c-99f0-451d0c8285c5.png)

- segment/364/Cj/Jpn
![Screenshot 2022-09-12 124918](https://user-images.githubusercontent.com/970948/189570498-e81025b8-69cf-4631-b97e-458ed55a5216.png)

- tokenize/132/Cj/Jpn
![Screenshot 2022-09-12 125002](https://user-images.githubusercontent.com/970948/189570565-6c3cd54a-937d-4cbc-bca5-ea043bd61c9c.png)

- tokenize/364/Cj/Jpn
![Screenshot 2022-09-12 125032](https://user-images.githubusercontent.com/970948/189570617-e9fc7716-3cbb-429c-a9f3-45b9a3cf20c1.png)

