### PR TITLE
Add Japanese normalizer to cover Katakana to Hiragana

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ unicode-segmentation = "1.6.0"
 whatlang = "0.16.1"
 lindera = { version = "=0.16.0", features = ["ipadic"], optional = true }
 pinyin = { version = "0.9", default-features = false, features = ["with_tone"], optional = true }
+wana_kana = "2.1.0"
 
 [features]
 default = ["chinese", "hebrew", "japanese", "thai"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ slice-group-by = "0.3.0"
 unicode-segmentation = "1.6.0"
 whatlang = "0.16.1"
 lindera = { version = "=0.16.0", features = ["ipadic"], optional = true }
-pinyin = { version = "0.9", default-features = false, features = ["with_tone"], optional = true }
-wana_kana = "2.1.0"
+pinyin = { version = "0.9", default-features = false, features = [
+  "with_tone",
+], optional = true }
+wana_kana = { version = "2.1.0", optional = true }
 
 [features]
 default = ["chinese", "hebrew", "japanese", "thai"]
@@ -35,6 +37,7 @@ hebrew = []
 
 # allow japanese specialized tokenization
 japanese = ["dep:lindera"]
+japanese-transliteration = ["dep:wana_kana"]
 
 # allow thai specialized tokenization
 thai = []

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Charabia provides a simple API to segment, normalize, or tokenize (segment + nor
 | **Latin** - **Any** | ✅ [unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation) | ✅ lowercase + deunicode            | 🟨 ~13MiB/sec    | 🟧 ~5MiB/sec    |
 | **Chinese** - **CMN** 🇨🇳 | ✅ [jieba](https://github.com/messense/jieba-rs) | ✅ traditional-to-simplified conversion | 🟨 ~9MiB/sec    | 🟧 ~5MiB/sec    |
 | **Hebrew** 🇮🇱 | ✅ [unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation) | ✅ diacritics removal  | 🟩 ~21MiB/sec    | 🟨 ~11MiB/sec    |
-| **Japanese** 🇯🇵 | ✅ [lindera](https://github.com/lindera-morphology/lindera) | ❌ | 🟧 ~5MiB/sec    | 🟧 ~4MiB/sec    |
+| **Japanese** 🇯🇵 | ✅ [lindera](https://github.com/lindera-morphology/lindera) | ✅ convert to Hiragana | 🟧 ~5MiB/sec    | 🟧 ~4MiB/sec    |
 | **Thai** 🇹🇭 | ✅ [dictionary based](https://github.com/PyThaiNLP/nlpo3) | ❌ | 🟩 ~23MiB/sec    | 🟨 ~14MiB/sec    |
 
 We aim to provide global language support, and your feedback helps us [move closer to that goal](https://docs.meilisearch.com/learn/advanced/language.html#improving-our-language-support). If you notice inconsistencies in your search results or the way your documents are processed, please open an issue on our [GitHub repository](https://github.com/meilisearch/charabia/issues/new/choose).

--- a/src/normalizer/japanese.rs
+++ b/src/normalizer/japanese.rs
@@ -1,0 +1,194 @@
+use std::borrow::Cow;
+
+use super::{Normalizer, NormalizerOption};
+use crate::detection::{Language, Script};
+use crate::Token;
+use wana_kana::is_hiragana::*;
+use wana_kana::to_hiragana::to_hiragana_with_opt;
+use wana_kana::Options;
+
+/// Japanese specialized [`Normalizer`].
+///
+/// This Normalizer uses [`wana_kana`] internally to convert Katakana and Kanji to Hiragana
+pub struct JapaneseNormalizer;
+
+impl Normalizer for JapaneseNormalizer {
+    fn normalize<'o>(
+        &self,
+        mut token: Token<'o>,
+        options: NormalizerOption,
+    ) -> Box<dyn Iterator<Item = Token<'o>> + 'o> {
+        if is_hiragana(token.lemma()) {
+            // No need to convert
+
+            if options.create_char_map && token.char_map.is_none() {
+                let mut char_map = Vec::new();
+                for c in token.lemma().chars() {
+                    char_map.push((c.len_utf8() as u8, c.len_utf8() as u8));
+                }
+                token.char_map = Some(char_map);
+            }
+        } else {
+            // Convert Katakana to Hiragana
+            let new_lemma = to_hiragana_with_opt(
+                token.lemma(),
+                Options {
+                    pass_romaji: true, // Otherwise 'ダメ駄目だめHi' would become 'だめ駄目だめひ'
+                    ..Default::default()
+                },
+            );
+
+            if options.create_char_map && token.char_map.is_none() {
+                debug_assert!(
+                    token.lemma().len() == new_lemma.len(),
+                    concat!(
+                        r#"`to_hiragana` changed the lemma len from {} to {} but the current `char_map` computation "#,
+                        r#"expected them to be equal. If `to_hiragana` does change len of char somehow, consider "#,
+                        r#"calling `to_hiragana(char)` char by char instead of only calling `to_hiragana(lemma)` once."#
+                    ),
+                    token.lemma().len(),
+                    new_lemma.len()
+                );
+                let old_new_chars = token.lemma().chars().zip(new_lemma.chars());
+
+                let mut char_map = Vec::new();
+                for (_i, (old_char, new_char)) in old_new_chars.enumerate() {
+                    char_map.push((old_char.len_utf8() as u8, new_char.len_utf8() as u8))
+                }
+                token.char_map = Some(char_map);
+            }
+
+            token.lemma = Cow::Owned(new_lemma);
+        }
+
+        Box::new(Some(token).into_iter())
+    }
+
+    fn should_normalize(&self, script: Script, language: Option<Language>) -> bool {
+        script == Script::Cj && matches!(language, None | Some(Language::Jpn))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow::Owned;
+
+    use crate::normalizer::test::test_normalizer;
+
+    // base tokens to normalize.
+    fn tokens() -> Vec<Token<'static>> {
+        vec![
+            Token {
+                lemma: Owned("だめ".to_string()),
+                char_end: 2,
+                byte_end: 6,
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+            Token {
+                lemma: Owned("だめ".to_string()),
+                char_end: 2,
+                byte_end: 6,
+                char_map: Some(vec![(3, 3), (3, 3)]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+            Token {
+                lemma: Owned("ダメ駄目だめHi".to_string()),
+                char_end: 8,
+                byte_end: 20,
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+        ]
+    }
+
+    // expected result of the current Normalizer.
+    fn normalizer_result() -> Vec<Token<'static>> {
+        vec![
+            Token {
+                lemma: Owned("だめ".to_string()),
+                char_end: 2,
+                byte_end: 6,
+                char_map: Some(vec![(3, 3), (3, 3)]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+            Token {
+                lemma: Owned("だめ".to_string()),
+                char_end: 2,
+                byte_end: 6,
+                char_map: Some(vec![(3, 3), (3, 3)]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+            Token {
+                lemma: Owned("だめ駄目だめHi".to_string()),
+                char_end: 8,
+                byte_end: 20,
+                char_map: Some(vec![
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (1, 1),
+                    (1, 1),
+                ]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+        ]
+    }
+
+    // expected result of the complete Normalizer pieline.
+    fn normalized_tokens() -> Vec<Token<'static>> {
+        vec![
+            Token {
+                lemma: Owned("だめ".to_string()),
+                char_end: 2,
+                byte_end: 6,
+                char_map: Some(vec![(3, 3), (3, 3)]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+            Token {
+                lemma: Owned("だめ".to_string()),
+                char_end: 2,
+                byte_end: 6,
+                char_map: Some(vec![(3, 3), (3, 3)]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+            Token {
+                lemma: Owned("だめ駄目だめHi".to_string()),
+                char_end: 8,
+                byte_end: 20,
+                char_map: Some(vec![
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (3, 3),
+                    (1, 1),
+                    (1, 1),
+                ]),
+                script: Script::Cj,
+                language: Some(Language::Jpn),
+                ..Default::default()
+            },
+        ]
+    }
+
+    test_normalizer!(JapaneseNormalizer, tokens(), normalizer_result(), normalized_tokens());
+}

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 #[cfg(feature = "chinese")]
 pub use self::chinese::ChineseNormalizer;
 pub use self::control_char::ControlCharNormalizer;
-#[cfg(feature = "japanese")]
+#[cfg(feature = "japanese-transliteration")]
 pub use self::japanese::JapaneseNormalizer;
 pub use self::latin::LatinNormalizer;
 pub use self::lowercase::LowercaseNormalizer;
@@ -14,7 +14,7 @@ use crate::Token;
 #[cfg(feature = "chinese")]
 mod chinese;
 mod control_char;
-#[cfg(feature = "japanese")]
+#[cfg(feature = "japanese-transliteration")]
 mod japanese;
 mod latin;
 mod lowercase;
@@ -26,7 +26,7 @@ pub static NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
         Box::new(LowercaseNormalizer),
         #[cfg(feature = "chinese")]
         Box::new(ChineseNormalizer),
-        #[cfg(feature = "japanese")]
+        #[cfg(feature = "japanese-transliteration")]
         Box::new(JapaneseNormalizer),
         Box::new(LatinNormalizer),
         Box::new(ControlCharNormalizer),

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -3,6 +3,8 @@ use once_cell::sync::Lazy;
 #[cfg(feature = "chinese")]
 pub use self::chinese::ChineseNormalizer;
 pub use self::control_char::ControlCharNormalizer;
+#[cfg(feature = "japanese")]
+pub use self::japanese::JapaneseNormalizer;
 pub use self::latin::LatinNormalizer;
 pub use self::lowercase::LowercaseNormalizer;
 use crate::detection::{Language, Script};
@@ -12,6 +14,8 @@ use crate::Token;
 #[cfg(feature = "chinese")]
 mod chinese;
 mod control_char;
+#[cfg(feature = "japanese")]
+mod japanese;
 mod latin;
 mod lowercase;
 mod nonspacing_mark;
@@ -22,6 +26,8 @@ pub static NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
         Box::new(LowercaseNormalizer),
         #[cfg(feature = "chinese")]
         Box::new(ChineseNormalizer),
+        #[cfg(feature = "japanese")]
+        Box::new(JapaneseNormalizer),
         Box::new(LatinNormalizer),
         Box::new(ControlCharNormalizer),
         Box::new(NonspacingMarkNormalizer),

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -44,7 +44,21 @@ mod test {
         "うち",
     ];
 
-    const TOKENIZED: &[&str] = SEGMENTED;
+    const TOKENIZED: &[&str] = &[
+        "関西",
+        "国際",
+        "空港",
+        "限定",
+        "とうとばっぐ",
+        " ",
+        "すもも",
+        "も",
+        "もも",
+        "も",
+        "もも",
+        "の",
+        "うち",
+    ];
 
     // Macro that run several tests on the Segmenter.
     test_segmenter!(JapaneseSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Cj, Language::Jpn);

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -49,7 +49,8 @@ mod test {
         "国際",
         "空港",
         "限定",
-        "とうとばっぐ",
+        // Use "とうとばっぐ" instead when feature "japanese-transliteration" is enabled or become default
+        "トートバッグ",
         " ",
         "すもも",
         "も",


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #131

## What does this PR do?
- Add a new Normalizer for Japanese, which converts Katakana to Hiragana

<!--
## TODOs before ready for review
- [x] Check the failing test `normalizer::control_char::test::global_normalize`
-->

<div id=limitations ></div>

## [#](#limitations) Limitations

### Converting from Kanji is not supported

From #131:
> ... for instance, `ダメ`, is also spelled `駄目`, or `だめ`
> ... [wana_kana](https://crates.io/crates/wana_kana) seems promising to convert everything in Hiragana

After some experiments and checking [convert options](https://docs.rs/wana_kana/2.1.0/wana_kana/struct.Options.html), it seems like [wana_kana](https://crates.io/crates/wana_kana) does not support converting Kanji to Hiragana or Romaji. For example:
- `to_hiragana("ダメ駄目だめ")` will be `"だめ駄目だめ"`
- `to_romaji("ダメ駄目だめ")` will be `"dame駄目dame"`


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
