### PR TITLE
Simplify normalizer implementation

### DIFF
--- a/src/normalizer/chinese.rs
+++ b/src/normalizer/chinese.rs
@@ -4,6 +4,7 @@ use pinyin::ToPinyin;
 
 use super::{Normalizer, NormalizerOption};
 use crate::detection::{Language, Script};
+use crate::Token;
 
 /// Normalize Chinese characters by converting them into Pinyin characters.
 ///
@@ -29,8 +30,8 @@ impl Normalizer for ChineseNormalizer {
         Cow::Owned(dst)
     }
 
-    fn should_normalize(&self, script: Script, language: Option<Language>) -> bool {
-        script == Script::Cj && matches!(language, None | Some(Language::Cmn))
+    fn should_normalize(&self, token: &Token) -> bool {
+        token.script == Script::Cj && matches!(token.language, None | Some(Language::Cmn))
     }
 }
 

--- a/src/normalizer/chinese.rs
+++ b/src/normalizer/chinese.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use pinyin::ToPinyin;
 
-use super::{Normalizer, NormalizerOption};
+use super::Normalizer;
 use crate::detection::{Language, Script};
 use crate::Token;
 
@@ -40,6 +40,7 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
+    use crate::normalizer::NormalizerOption;
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {

--- a/src/normalizer/control_char.rs
+++ b/src/normalizer/control_char.rs
@@ -2,61 +2,14 @@ use std::borrow::Cow;
 
 use super::{Normalizer, NormalizerOption};
 use crate::detection::{Language, Script};
-use crate::Token;
 
 /// A global [`Normalizer`] removing control characters.
 ///
 pub struct ControlCharNormalizer;
 
 impl Normalizer for ControlCharNormalizer {
-    fn normalize<'o>(
-        &self,
-        mut token: Token<'o>,
-        _options: NormalizerOption,
-    ) -> Box<dyn Iterator<Item = Token<'o>> + 'o> {
-        if token.lemma().chars().any(is_control) {
-            let mut lemma = String::new();
-            let char_map = match token.char_map.take() {
-                // modify the current char map
-                Some(mut char_map) => {
-                    let mut byte_index = 0;
-                    for (_, normalized_char_length) in char_map.iter_mut() {
-                        let subset: String = token.lemma
-                            [byte_index as usize..(byte_index + *normalized_char_length) as usize]
-                            .chars()
-                            .filter(|c| !is_control(*c))
-                            .collect();
-                        byte_index += *normalized_char_length;
-                        *normalized_char_length = subset.len() as u8;
-                        lemma.push_str(&subset);
-                    }
-
-                    char_map
-                }
-                // create and compute a new char map
-                None => {
-                    let mut char_map = Vec::new();
-                    for c in token.lemma().chars() {
-                        let char_len = c.len_utf8() as u8;
-                        if is_control(c) {
-                            // skip character
-                            char_map.push((char_len, 0));
-                        } else {
-                            char_map.push((char_len, char_len));
-                            lemma.push(c);
-                        }
-                    }
-
-                    char_map
-                }
-            };
-
-            token.lemma = Cow::Owned(lemma);
-            token.char_map = Some(char_map);
-        }
-
-        // Create an iterator over the normalized token.
-        Box::new(Some(token).into_iter())
+    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
+        src.chars().filter(|c| !is_control(*c)).collect()
     }
 
     fn should_normalize(&self, _script: Script, _language: Option<Language>) -> bool {

--- a/src/normalizer/control_char.rs
+++ b/src/normalizer/control_char.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::{Normalizer, NormalizerOption};
+use super::Normalizer;
 use crate::Token;
 
 /// A global [`Normalizer`] removing control characters.
@@ -26,6 +26,7 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
+    use crate::normalizer::NormalizerOption;
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {

--- a/src/normalizer/control_char.rs
+++ b/src/normalizer/control_char.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use super::{Normalizer, NormalizerOption};
-use crate::detection::{Language, Script};
+use crate::Token;
 
 /// A global [`Normalizer`] removing control characters.
 ///
@@ -12,8 +12,8 @@ impl Normalizer for ControlCharNormalizer {
         src.chars().filter(|c| !is_control(*c)).collect()
     }
 
-    fn should_normalize(&self, _script: Script, _language: Option<Language>) -> bool {
-        true
+    fn should_normalize(&self, token: &Token) -> bool {
+        token.lemma().chars().any(is_control)
     }
 }
 

--- a/src/normalizer/control_char.rs
+++ b/src/normalizer/control_char.rs
@@ -1,15 +1,14 @@
-use std::borrow::Cow;
-
-use super::Normalizer;
+use super::CharNormalizer;
+use crate::normalizer::CharOrStr;
 use crate::Token;
 
 /// A global [`Normalizer`] removing control characters.
 ///
 pub struct ControlCharNormalizer;
 
-impl Normalizer for ControlCharNormalizer {
-    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        src.chars().filter(|c| !is_control(*c)).collect()
+impl CharNormalizer for ControlCharNormalizer {
+    fn normalize_char(&self, c: char) -> Option<CharOrStr> {
+        (!is_control(c)).then(|| c.into())
     }
 
     fn should_normalize(&self, token: &Token) -> bool {
@@ -26,7 +25,7 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
-    use crate::normalizer::NormalizerOption;
+    use crate::normalizer::{Normalizer, NormalizerOption};
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {

--- a/src/normalizer/dummy_example.rs
+++ b/src/normalizer/dummy_example.rs
@@ -1,8 +1,5 @@
-use std::borrow::Cow;
-
-// Import `Normalizer` trait.
-use super::{Normalizer, NormalizerOption};
-use crate::detection::{Language, Script};
+// Import `CharNormalizer` trait.
+use super::{CharNormalizer, CharOrStr};
 use crate::Token;
 
 // Make a small documentation of the specialized Normalizer like below.
@@ -12,12 +9,28 @@ use crate::Token;
 /// <OptionalAdditionnalExplanations>
 pub struct DummyNormalizer;
 
-// All normalizers only need to implement the method `normalize` and the method `should_normalize` of the `Normalizer` trait.
-impl Normalizer for DummyNormalizer {
-    // Creates the normalized version of the provided string.
-    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        // lowercase the provided string.
-        Cow::Owned(src.to_lowercase());
+// All normalizers only need to implement the method `normalize_char` and the method `should_normalize` of the `CharNormalizer` trait.
+impl CharNormalizer for DummyNormalizer {
+    // Creates the normalized version of the provided char.
+    // In this example we will remove whitespaces and lowercase other characters.
+    fn normalize_char(&self, c: char) -> Option<CharOrStr> {
+        if c.is_whitespace() {
+            // return None to remove the current character.
+            None
+        } else if c.is_lowercase() {
+            // the current character is already lowercased.
+
+            // return Some of the orginal version to keep the original character.
+            // note that `into()` will convert any `char` or `String` into the expected type `CharOrStr`.
+            Some(c.into())
+        } else {
+            // lowercase the provided char.
+            let normalized: String = c.to_lowercase().collect();
+
+            // return Some of the normalized version to apply this normalized version.
+            // note that `into()` will convert any `char` or `String` into the expected type `CharOrStr`.
+            Some(normalized.into())
+        }
     }
 
     // Returns `true` if the Normalizer should be used.
@@ -41,67 +54,40 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
+    use crate::normalizer::Normalizer;
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {
-        vec![
-            Token {
-                lemma: Owned("PascalCase".to_string()),
-                char_end: 10,
-                byte_end: 10,
-                script: Script::Latin,
-                ..Default::default()
-            },
-            Token {
-                lemma: Owned("ПаскальКейс".to_string()),
-                char_end: 11,
-                byte_end: 22,
-                script: Script::Latin,
-                ..Default::default()
-            },
-        ]
+        vec![Token {
+            lemma: Owned("Pascal Case".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Latin,
+            ..Default::default()
+        }]
     }
 
     // expected result of the current Normalizer.
     fn normalizer_result() -> Vec<Token<'static>> {
-        vec![
-            Token {
-                // lowercased
-                lemma: Owned("pascalcase".to_string()),
-                char_end: 10,
-                byte_end: 10,
-                script: Script::Latin,
-                ..Default::default()
-            },
-            Token {
-                // lowercased
-                lemma: Owned("паскалькейс".to_string()),
-                char_end: 11,
-                byte_end: 22,
-                script: Script::Latin,
-                ..Default::default()
-            },
-        ]
+        vec![Token {
+            // lowercased
+            lemma: Owned("pascalcase".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Latin,
+            ..Default::default()
+        }]
     }
 
     // expected result of the complete Normalizer pieline.
     fn normalized_tokens() -> Vec<Token<'static>> {
-        vec![
-            Token {
-                lemma: Owned("pascalcase".to_string()),
-                char_end: 10,
-                byte_end: 10,
-                script: Script::Latin,
-                ..Default::default()
-            },
-            Token {
-                lemma: Owned("paskal'keis".to_string()),
-                char_end: 11,
-                byte_end: 22,
-                script: Script::Latin,
-                ..Default::default()
-            },
-        ]
+        vec![Token {
+            lemma: Owned("pascalcase".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Latin,
+            ..Default::default()
+        }]
     }
 
     test_normalizer!(DummyNormalizer, tokens(), normalizer_result(), normalized_tokens());

--- a/src/normalizer/dummy_example.rs
+++ b/src/normalizer/dummy_example.rs
@@ -21,9 +21,11 @@ impl Normalizer for DummyNormalizer {
     }
 
     // Returns `true` if the Normalizer should be used.
-    fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {
-        // here we lowercase only on Latin and Cyrillic Scripts.
-        script == Script::Latin && script == Script::Cyrillic
+    fn should_normalize(&self, token: &Token) -> bool {
+        // here we lowercase only on Latin and Cyrillic Scripts and if the current token contains an uppercased character.
+        token.script == Script::Latin
+            && token.script == Script::Cyrillic
+            && token.lemma.chars().any(char::is_uppercase)
     }
 }
 

--- a/src/normalizer/dummy_example.rs
+++ b/src/normalizer/dummy_example.rs
@@ -14,13 +14,10 @@ pub struct DummyNormalizer;
 
 // All normalizers only need to implement the method `normalize` and the method `should_normalize` of the `Normalizer` trait.
 impl Normalizer for DummyNormalizer {
-    // Creates an iterator over the normalized version of the provided token.
-    fn normalize<'o>(&self, mut token: Token<'o>, options: NormalizerOption) -> Box<dyn Iterator<Item = Token<'o>> + 'o> {
-        // lowercase the provided token lemma.
-        token.lemma = Cow::Owned(token.lemma().to_lowercase());
-
-        // Create an iterator over the normalized token.
-        Box::new(Some(token).into_iter())
+    // Creates the normalized version of the provided string.
+    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
+        // lowercase the provided string.
+        Cow::Owned(src.to_lowercase());
     }
 
     // Returns `true` if the Normalizer should be used.

--- a/src/normalizer/japanese.rs
+++ b/src/normalizer/japanese.rs
@@ -24,24 +24,17 @@ impl Normalizer for JapaneseNormalizer {
     // converting katakana to hiragana doesn't change the characters length,
     // so the `normalize` method is overloaded to skip the useless char_map computing.
     fn normalize<'o>(&self, mut token: Token<'o>, _options: NormalizerOption) -> Token<'o> {
-        if let Cow::Owned(lemma) = self.normalize_str(token.lemma()) {
-            token.lemma = Cow::Owned(lemma);
-        }
-
-        token
-    }
-
-    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
         // Convert Katakana to Hiragana
         let dst = to_hiragana_with_opt(
-            src,
+            token.lemma(),
             Options {
                 pass_romaji: true, // Otherwise 'ダメ駄目だめHi' would become 'だめ駄目だめひ'
                 ..Default::default()
             },
         );
 
-        Cow::Owned(dst)
+        token.lemma = Cow::Owned(dst);
+        token
     }
 
     fn should_normalize(&self, token: &Token) -> bool {

--- a/src/normalizer/japanese.rs
+++ b/src/normalizer/japanese.rs
@@ -32,24 +32,22 @@ impl Normalizer for JapaneseNormalizer {
     }
 
     fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        if is_hiragana(src) {
-            Cow::Borrowed(src)
-        } else {
-            // Convert Katakana to Hiragana
-            let dst = to_hiragana_with_opt(
-                src,
-                Options {
-                    pass_romaji: true, // Otherwise 'ダメ駄目だめHi' would become 'だめ駄目だめひ'
-                    ..Default::default()
-                },
-            );
+        // Convert Katakana to Hiragana
+        let dst = to_hiragana_with_opt(
+            src,
+            Options {
+                pass_romaji: true, // Otherwise 'ダメ駄目だめHi' would become 'だめ駄目だめひ'
+                ..Default::default()
+            },
+        );
 
-            Cow::Owned(dst)
-        }
+        Cow::Owned(dst)
     }
 
-    fn should_normalize(&self, script: Script, language: Option<Language>) -> bool {
-        script == Script::Cj && matches!(language, None | Some(Language::Jpn))
+    fn should_normalize(&self, token: &Token) -> bool {
+        token.script == Script::Cj
+            && matches!(token.language, None | Some(Language::Jpn))
+            && !is_hiragana(token.lemma())
     }
 }
 

--- a/src/normalizer/latin.rs
+++ b/src/normalizer/latin.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use deunicode::deunicode;
 
-use super::{Normalizer, NormalizerOption};
+use super::Normalizer;
 use crate::detection::Script;
 use crate::Token;
 
@@ -26,6 +26,7 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
+    use crate::normalizer::NormalizerOption;
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {

--- a/src/normalizer/latin.rs
+++ b/src/normalizer/latin.rs
@@ -3,7 +3,8 @@ use std::borrow::Cow;
 use deunicode::deunicode;
 
 use super::{Normalizer, NormalizerOption};
-use crate::detection::{Language, Script};
+use crate::detection::Script;
+use crate::Token;
 
 /// Latin specialized [`Normalizer`] converting unicode chars into Ascii.
 ///
@@ -12,15 +13,11 @@ pub struct LatinNormalizer;
 
 impl Normalizer for LatinNormalizer {
     fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        if src.is_ascii() {
-            Cow::Borrowed(src)
-        } else {
-            Cow::Owned(deunicode(src))
-        }
+        Cow::Owned(deunicode(src))
     }
 
-    fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {
-        script == Script::Latin
+    fn should_normalize(&self, token: &Token) -> bool {
+        token.script == Script::Latin && !token.lemma().is_ascii()
     }
 }
 

--- a/src/normalizer/latin.rs
+++ b/src/normalizer/latin.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
 
-use deunicode::{deunicode, deunicode_char};
+use deunicode::deunicode;
 
 use super::{Normalizer, NormalizerOption};
 use crate::detection::{Language, Script};
-use crate::Token;
 
 /// Latin specialized [`Normalizer`] converting unicode chars into Ascii.
 ///
@@ -12,30 +11,12 @@ use crate::Token;
 pub struct LatinNormalizer;
 
 impl Normalizer for LatinNormalizer {
-    fn normalize<'o>(
-        &self,
-        mut token: Token<'o>,
-        options: NormalizerOption,
-    ) -> Box<dyn Iterator<Item = Token<'o>> + 'o> {
-        if !token.lemma().is_ascii() {
-            let mut lemma = String::new();
-            if options.create_char_map {
-                let mut char_map = Vec::new();
-                for c in token.lemma().chars() {
-                    // if a char can't be deunicoded, skip it.
-                    let deunicoded = deunicode_char(c).unwrap_or("").trim();
-                    char_map.push((c.len_utf8() as u8, deunicoded.len() as u8));
-                    lemma.push_str(&deunicoded);
-                }
-                token.char_map = Some(char_map);
-            } else {
-                lemma.push_str(&deunicode(token.lemma()));
-            }
-            token.lemma = Cow::Owned(lemma);
+    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
+        if src.is_ascii() {
+            Cow::Borrowed(src)
+        } else {
+            Cow::Owned(deunicode(src))
         }
-
-        // Create an iterator over the normalized token.
-        Box::new(Some(token).into_iter())
     }
 
     fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {

--- a/src/normalizer/lowercase.rs
+++ b/src/normalizer/lowercase.rs
@@ -12,15 +12,9 @@ impl Normalizer for LowercaseNormalizer {
     // lowercasing characters doesn't change the characters length,
     // so the `normalize` method is overloaded to skip the useless char_map computing.
     fn normalize<'o>(&self, mut token: Token<'o>, _options: NormalizerOption) -> Token<'o> {
-        if let Cow::Owned(lemma) = self.normalize_str(token.lemma()) {
-            token.lemma = Cow::Owned(lemma);
-        }
+        token.lemma = Cow::Owned(token.lemma().to_lowercase());
 
         token
-    }
-
-    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        Cow::Owned(src.to_lowercase())
     }
 
     fn should_normalize(&self, token: &Token) -> bool {

--- a/src/normalizer/lowercase.rs
+++ b/src/normalizer/lowercase.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use super::{Normalizer, NormalizerOption};
-use crate::detection::{Language, Script};
+use crate::detection::Script;
 use crate::Token;
 
 /// A global [`Normalizer`] lowercasing characters.
@@ -20,16 +20,13 @@ impl Normalizer for LowercaseNormalizer {
     }
 
     fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        if src.chars().any(char::is_uppercase) {
-            Cow::Owned(src.to_lowercase())
-        } else {
-            Cow::Borrowed(src)
-        }
+        Cow::Owned(src.to_lowercase())
     }
 
-    fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {
+    fn should_normalize(&self, token: &Token) -> bool {
         // https://en.wikipedia.org/wiki/Letter_case#Capitalisation
-        matches!(script, Script::Latin | Script::Cyrillic | Script::Greek | Script::Georgian)
+        matches!(token.script, Script::Latin | Script::Cyrillic | Script::Greek | Script::Georgian)
+            && token.lemma.chars().any(char::is_uppercase)
     }
 }
 

--- a/src/normalizer/nonspacing_mark.rs
+++ b/src/normalizer/nonspacing_mark.rs
@@ -1,10 +1,10 @@
-use std::borrow::Cow;
 use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
 
-use super::Normalizer;
+use super::CharNormalizer;
 use crate::detection::Script;
+use crate::normalizer::CharOrStr;
 use crate::Token;
 
 static NONSPACING_MARKS: Lazy<HashSet<u32>> = Lazy::new(|| {
@@ -20,9 +20,9 @@ static NONSPACING_MARKS: Lazy<HashSet<u32>> = Lazy::new(|| {
 /// This normalizer uses built-in `HashSet` internally to check over the marks set
 pub struct NonspacingMarkNormalizer;
 
-impl Normalizer for NonspacingMarkNormalizer {
-    fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        src.chars().filter(|c| !is_nonspacing_mark(*c)).collect()
+impl CharNormalizer for NonspacingMarkNormalizer {
+    fn normalize_char(&self, c: char) -> Option<CharOrStr> {
+        (!is_nonspacing_mark(c)).then(|| c.into())
     }
 
     fn should_normalize(&self, token: &Token) -> bool {
@@ -41,7 +41,7 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
-    use crate::normalizer::NormalizerOption;
+    use crate::normalizer::{Normalizer, NormalizerOption};
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {

--- a/src/normalizer/nonspacing_mark.rs
+++ b/src/normalizer/nonspacing_mark.rs
@@ -4,7 +4,8 @@ use std::collections::HashSet;
 use once_cell::sync::Lazy;
 
 use super::{Normalizer, NormalizerOption};
-use crate::detection::{Language, Script};
+use crate::detection::Script;
+use crate::Token;
 
 static NONSPACING_MARKS: Lazy<HashSet<u32>> = Lazy::new(|| {
     let bytes = include_bytes!("../../dictionaries/bin/nonspacing_mark/marks.bin");
@@ -21,15 +22,12 @@ pub struct NonspacingMarkNormalizer;
 
 impl Normalizer for NonspacingMarkNormalizer {
     fn normalize_str<'o>(&self, src: &'o str) -> Cow<'o, str> {
-        if src.chars().any(is_nonspacing_mark) {
-            src.chars().filter(|c| !is_nonspacing_mark(*c)).collect()
-        } else {
-            Cow::Borrowed(src)
-        }
+        src.chars().filter(|c| !is_nonspacing_mark(*c)).collect()
     }
 
-    fn should_normalize(&self, script: Script, _language: Option<Language>) -> bool {
-        matches!(script, Script::Hebrew | Script::Thai | Script::Arabic)
+    fn should_normalize(&self, token: &Token) -> bool {
+        matches!(token.script, Script::Hebrew | Script::Thai | Script::Arabic)
+            && token.lemma().chars().any(is_nonspacing_mark)
     }
 }
 

--- a/src/normalizer/nonspacing_mark.rs
+++ b/src/normalizer/nonspacing_mark.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
 
-use super::{Normalizer, NormalizerOption};
+use super::Normalizer;
 use crate::detection::Script;
 use crate::Token;
 
@@ -41,6 +41,7 @@ mod test {
     use std::borrow::Cow::Owned;
 
     use crate::normalizer::test::test_normalizer;
+    use crate::normalizer::NormalizerOption;
 
     // base tokens to normalize.
     fn tokens() -> Vec<Token<'static>> {

--- a/src/segmenter/japanese.rs
+++ b/src/segmenter/japanese.rs
@@ -50,6 +50,9 @@ mod test {
         "空港",
         "限定",
         // Use "とうとばっぐ" instead when feature "japanese-transliteration" is enabled or become default
+        #[cfg(feature = "japanese-transliteration")]
+        "とうとばっぐ",
+        #[cfg(not(feature = "japanese-transliteration"))]
         "トートバッグ",
         " ",
         "すもも",


### PR DESCRIPTION
- Create a trait `CharNormalizer`:
  - Add a method `normalize_char` to the `CharNormalizer` trait that needs to be implemented in each normalizer
  - Add a method `normalize_str` to the `CharNormalizer` trait with a default implementation that normalizes a provided string without bothering with the `char_map` calling the method `normalize_char`.

- the method `normalize` of  the `Normalizer` trait now has a default implementation for the `CharNormalizer` trait that handles the `char_map` creation and calls `normalize_str` to normalize the token
  - this avoids implementing the char_map computing for each normalizer which will ease the future contributions 
  - this can be overridden if the char_map computing is useless for a normalizer
- the method `should_normalize` takes now a reference to the whole `Token` in parameters extending the normalizing conditions. 

Fix #156