### PR TITLE
Classify tokens after Segmentation

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 /// Iterator over tuples of [`&str`] (part of the original text) and [`Token`].
 pub struct ReconstructedTokenIter<'o, 'sw, A: AsRef<[u8]>> {
-    token_iter: NormalizedTokenIter<'o, 'sw, A>,
+    token_iter: NormalizedTokenIter<'o>,
     original: &'o str,
 }
 
@@ -51,7 +51,7 @@ pub trait Tokenize<'o, A: AsRef<[u8]>> {
     /// assert_eq!(lemma, "quick");
     /// assert_eq!(kind, TokenKind::Word);
     /// ```
-    fn tokenize(&self) -> NormalizedTokenIter<'o, '_, A>;
+    fn tokenize(&self) -> NormalizedTokenIter<'o>;
 
     /// Attaches each [`Token`] to its corresponding portion of the original text.
     ///
@@ -83,7 +83,7 @@ pub trait Tokenize<'o, A: AsRef<[u8]>> {
 }
 
 impl<'o> Tokenize<'o, Vec<u8>> for &'o str {
-    fn tokenize(&self) -> NormalizedTokenIter<'o, '_, Vec<u8>> {
+    fn tokenize(&self) -> NormalizedTokenIter<'o> {
         self.segment().classify().normalize(NormalizerOption::default())
     }
 
@@ -103,7 +103,7 @@ pub struct Tokenizer<'sw, 'al, A> {
 
 impl<'o, A: AsRef<[u8]>> Tokenizer<'_, 'o, A>
 {
-    pub fn tokenize(&self, original: &'o str) -> NormalizedTokenIter<'o, '_, A> {
+    pub fn tokenize(&self, original: &'o str) -> NormalizedTokenIter<'o> {
         original
             .segment_with_allowlist(self.allow_list)
             .classify_with_stop_words(self.stop_words)

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,7 +1,7 @@
 use fst::Set;
 
 use crate::classifier::{ClassifiedTokenIter, Classify};
-use crate::normalizer::{Normalize, NormalizerOption};
+use crate::normalizer::{NormalizedTokenIter, Normalize, NormalizerOption};
 use crate::segmenter::{Segment, SegmentedTokenIter};
 use crate::Token;
 use crate::detection::{Language,Script};
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 /// Iterator over tuples of [`&str`] (part of the original text) and [`Token`].
 pub struct ReconstructedTokenIter<'o, 'sw, A: AsRef<[u8]>> {
-    token_iter: ClassifiedTokenIter<'o, 'sw, A>,
+    token_iter: NormalizedTokenIter<'o, 'sw, A>,
     original: &'o str,
 }
 
@@ -51,7 +51,7 @@ pub trait Tokenize<'o, A: AsRef<[u8]>> {
     /// assert_eq!(lemma, "quick");
     /// assert_eq!(kind, TokenKind::Word);
     /// ```
-    fn tokenize(&self) -> ClassifiedTokenIter<'o, '_, A>;
+    fn tokenize(&self) -> NormalizedTokenIter<'o, '_, A>;
 
     /// Attaches each [`Token`] to its corresponding portion of the original text.
     ///
@@ -83,7 +83,7 @@ pub trait Tokenize<'o, A: AsRef<[u8]>> {
 }
 
 impl<'o> Tokenize<'o, Vec<u8>> for &'o str {
-    fn tokenize(&self) -> ClassifiedTokenIter<'o, '_, Vec<u8>> {
+    fn tokenize(&self) -> NormalizedTokenIter<'o, '_, Vec<u8>> {
         self.segment().classify().normalize(NormalizerOption::default())
     }
 
@@ -103,7 +103,7 @@ pub struct Tokenizer<'sw, 'al, A> {
 
 impl<'o, A: AsRef<[u8]>> Tokenizer<'_, 'o, A>
 {
-    pub fn tokenize(&self, original: &'o str) -> ClassifiedTokenIter<'o, '_, A> {
+    pub fn tokenize(&self, original: &'o str) -> NormalizedTokenIter<'o, '_, A> {
         original
             .segment_with_allowlist(self.allow_list)
             .classify_with_stop_words(self.stop_words)

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -84,7 +84,7 @@ pub trait Tokenize<'o, A: AsRef<[u8]>> {
 
 impl<'o> Tokenize<'o, Vec<u8>> for &'o str {
     fn tokenize(&self) -> ClassifiedTokenIter<'o, '_, Vec<u8>> {
-        self.segment().normalize(NormalizerOption::default()).classify()
+        self.segment().classify().normalize(NormalizerOption::default())
     }
 
     fn reconstruct(&self) -> ReconstructedTokenIter<'o, '_, Vec<u8>> {
@@ -106,8 +106,8 @@ impl<'o, A: AsRef<[u8]>> Tokenizer<'_, 'o, A>
     pub fn tokenize(&self, original: &'o str) -> ClassifiedTokenIter<'o, '_, A> {
         original
             .segment_with_allowlist(self.allow_list)
-            .normalize(self.normalizer_option)
             .classify_with_stop_words(self.stop_words)
+            .normalize(self.normalizer_option)
     }
 
     pub fn reconstruct(&self, original: &'o str) -> ReconstructedTokenIter<'o, '_, A> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,6 +1,6 @@
 use fst::Set;
 
-use crate::classifier::{ClassifiedTokenIter, Classify};
+use crate::classifier::{Classify};
 use crate::normalizer::{NormalizedTokenIter, Normalize, NormalizerOption};
 use crate::segmenter::{Segment, SegmentedTokenIter};
 use crate::Token;
@@ -8,7 +8,7 @@ use crate::detection::{Language,Script};
 use std::collections::HashMap;
 
 /// Iterator over tuples of [`&str`] (part of the original text) and [`Token`].
-pub struct ReconstructedTokenIter<'o, 'sw, A: AsRef<[u8]>> {
+pub struct ReconstructedTokenIter<'o: AsRef<[u8]>> {
     token_iter: NormalizedTokenIter<'o>,
     original: &'o str,
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -8,12 +8,12 @@ use crate::detection::{Language,Script};
 use std::collections::HashMap;
 
 /// Iterator over tuples of [`&str`] (part of the original text) and [`Token`].
-pub struct ReconstructedTokenIter<'o: AsRef<[u8]>> {
+pub struct ReconstructedTokenIter<'o> {
     token_iter: NormalizedTokenIter<'o>,
     original: &'o str,
 }
 
-impl<'o, A: AsRef<[u8]>> Iterator for ReconstructedTokenIter<'o, '_, A> {
+impl<'o, A: AsRef<[u8]>> Iterator for ReconstructedTokenIter<'o> {
     type Item = (&'o str, Token<'o>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -79,7 +79,7 @@ pub trait Tokenize<'o, A: AsRef<[u8]>> {
     /// assert_eq!(lemma, "quick");
     /// assert_eq!(kind, TokenKind::Word);
     /// ```
-    fn reconstruct(&self) -> ReconstructedTokenIter<'o, '_, A>;
+    fn reconstruct(&self) -> ReconstructedTokenIter<'o>;
 }
 
 impl<'o> Tokenize<'o, Vec<u8>> for &'o str {
@@ -87,7 +87,7 @@ impl<'o> Tokenize<'o, Vec<u8>> for &'o str {
         self.segment().classify().normalize(NormalizerOption::default())
     }
 
-    fn reconstruct(&self) -> ReconstructedTokenIter<'o, '_, Vec<u8>> {
+    fn reconstruct(&self) -> ReconstructedTokenIter<'o> {
         ReconstructedTokenIter { token_iter: self.tokenize(), original: self }
     }
 }
@@ -110,7 +110,7 @@ impl<'o, A: AsRef<[u8]>> Tokenizer<'_, 'o, A>
             .normalize(self.normalizer_option)
     }
 
-    pub fn reconstruct(&self, original: &'o str) -> ReconstructedTokenIter<'o, '_, A> {
+    pub fn reconstruct(&self, original: &'o str) -> ReconstructedTokenIter<'o> {
         ReconstructedTokenIter { original: original, token_iter: self.tokenize(original) }
     }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #150 

## What does this PR do?
Classifying tokens after Segmentation instead of Normalization in the tokenization pipeline to enhance the precision of the stop_words classification.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
