### PR TITLE
Import kVariants.tsv correctly with include_str! instead of File::open

### DIFF
--- a/src/normalizer/chinese/kvariants.rs
+++ b/src/normalizer/chinese/kvariants.rs
@@ -1,7 +1,6 @@
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::fs;
 
 #[derive(Debug, PartialEq)]
 pub enum KVariantClass {
@@ -34,9 +33,9 @@ pub static KVARIANTS: Lazy<HashMap<char, KVariant>> = Lazy::new(|| {
     //   㓻 (U+34FB)	sem	    剛 (U+525B)
     //   ...
     //
-    let file = fs::File::open("dictionaries/txt/chinese/kVariants.tsv").unwrap();
+    let tsv = include_str!("../../../dictionaries/txt/chinese/kVariants.tsv");
     let mut reader =
-        csv::ReaderBuilder::new().delimiter(b'\t').has_headers(false).from_reader(file);
+        csv::ReaderBuilder::new().delimiter(b'\t').has_headers(false).from_reader(tsv.as_bytes());
 
     let mut map: HashMap<char, KVariant> = HashMap::new();
     for result in reader.deserialize() {


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes https://github.com/meilisearch/charabia/pull/162/files#r1029294766

## What does this PR do?

In #162, I use `File::open` to import `kVariants.tsv`, which I'm not sure if it will work after packaged to create. In this PR I switch to use `include_str!` instead.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
