### PR TITLE
Classify a Token before normalizing it avoiding to have false positive in stop words

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,7 @@ mod detection;
 mod token;
 mod tokenizer;
 
-pub use classifier::Classify;
 pub use detection::{Language, Script};
-pub use normalizer::Normalize;
 pub use segmenter::Segment;
 pub use token::{SeparatorKind, Token, TokenKind};
 


### PR DESCRIPTION
This change needed a refactor in order to better control lifetimes in the Library.

Fixes #150