### PR TITLE
Split camelCase in Latin segmenter

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -18,6 +18,7 @@ deunicode = "1.1.1"
 fst = "0.4"
 jieba-rs = { version = "0.6", optional = true }
 once_cell = "1.5.2"
+regex = "1.7.1"
 serde = "1.0"
 slice-group-by = "0.3.0"
 unicode-segmentation = "1.6.0"

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -18,7 +18,7 @@ deunicode = "1.1.1"
 fst = "0.4"
 jieba-rs = { version = "0.6", optional = true }
 once_cell = "1.5.2"
-regex = "1.7.1"
+regex = { version = "1.7.1", optional = true }
 serde = "1.0"
 slice-group-by = "0.3.0"
 unicode-segmentation = "1.6.0"
@@ -34,7 +34,7 @@ unicode-normalization = "0.1.22"
 irg-kvariants = "0.1.0"
 
 [features]
-default = ["chinese", "hebrew", "japanese", "thai", "korean", "greek"]
+default = ["chinese", "hebrew", "japanese", "thai", "korean", "greek", "latin-camelcase"]
 
 # allow chinese specialized tokenization
 chinese = ["dep:pinyin", "dep:jieba-rs"]
@@ -54,6 +54,9 @@ thai = []
 
 # allow greek specialized tokenization
 greek = []
+
+# allow splitting camelCase latin words
+latin-camelcase = ["dep:regex"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/charabia/src/segmenter/camel_case.rs
+++ b/charabia/src/segmenter/camel_case.rs
@@ -63,3 +63,23 @@ impl<'t> Iterator for CamelCaseParts<'t> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::CamelCaseSegmentation;
+
+    macro_rules! test_segmentation {
+        ($text:expr, $segmented:expr, $name:ident) => {
+            #[test]
+            fn $name() {
+                let segmented_text: Vec<_> = $text.split_camel_case_bounds().collect();
+                assert_eq!(segmented_text, $segmented);
+            }
+        };
+    }
+
+    test_segmentation!("camelCase", ["camel", "Case"], camel_case_is_split);
+    test_segmentation!("SCREAMING", ["SCREAMING"], all_caps_is_not_split);
+    test_segmentation!("resuméWriter", ["resumé", "Writer"], non_ascii_boundary_on_left);
+    test_segmentation!("KarelČapek", ["Karel", "Čapek"], non_ascii_boundary_on_right);
+}

--- a/charabia/src/segmenter/camel_case.rs
+++ b/charabia/src/segmenter/camel_case.rs
@@ -1,0 +1,56 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub(crate) trait CamelCaseSegmentation {
+    /// Returns an iterator over substrings of `self` separated on camelCase boundaries.
+    /// For instance, "camelCase" is split into ["camel", "Case"].
+    /// A camelCase boundary constitutes a lowercase letter directly followed by an uppercase letter
+    /// where lower and uppercase letters are defined by the corresponding Unicode General Categories.
+    fn split_camel_case_bounds(&self) -> CamelCaseParts;
+}
+
+pub(crate) struct CamelCaseParts<'t> {
+    state: State<'t>,
+}
+
+enum State<'t> {
+    InProgress { remainder: &'t str },
+    Exhausted,
+}
+
+impl CamelCaseSegmentation for str {
+    fn split_camel_case_bounds(&self) -> CamelCaseParts {
+        CamelCaseParts { state: State::InProgress { remainder: self } }
+    }
+}
+
+/// Matches a lower-case letter followed by an upper-case one and captures
+/// the boundary between them with a group named "boundary".
+static CAMEL_CASE_BOUNDARY_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\p{Ll}(?P<boundary>)\p{Lu}").unwrap());
+
+impl<'t> Iterator for CamelCaseParts<'t> {
+    type Item = &'t str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.state {
+            State::Exhausted => None,
+            State::InProgress { remainder } => {
+                match CAMEL_CASE_BOUNDARY_REGEX.captures(remainder) {
+                    Some(captures) => {
+                        // By the nature of the regex, this group is always present and this should never panic.
+                        let boundary = captures.name("boundary").unwrap().start();
+                        self.state = State::InProgress { remainder: &remainder[boundary..] };
+                        Some(&remainder[..boundary])
+                    }
+                    None => {
+                        // All boundaries processed. Mark `self` as exhausted.
+                        self.state = State::Exhausted;
+                        // But don't forget to yield the part of the string remaining after the last boundary.
+                        Some(remainder)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charabia/src/segmenter/latin.rs
+++ b/charabia/src/segmenter/latin.rs
@@ -23,18 +23,18 @@ impl Segmenter for LatinSegmenter {
 mod test {
     use crate::segmenter::test::test_segmenter;
 
-    const TEXT: &str = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F! camelCase PascalCase IJsland CASE";
+    const TEXT: &str = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F! camelCase PascalCase IJsland CASE resuméWriter";
     const SEGMENTED: &[&str] = &[
         "The", " ", "quick", " ", "(", "\"", "brown", "\"", ")", " ", "fox", " ", "can'", "t", " ",
         "jump", " ", "32.3", " ", "feet", ",", " ", "right", "?", " ", "Brr", ",", " ", "it'", "s",
         " ", "29.3", "°", "F", "!", " ", "camel", "Case", " ", "Pascal", "Case", " ", "IJsland",
-        " ", "CASE",
+        " ", "CASE", " ", "resumé", "Writer",
     ];
     const TOKENIZED: &[&str] = &[
         "the", " ", "quick", " ", "(", "\"", "brown", "\"", ")", " ", "fox", " ", "can'", "t", " ",
         "jump", " ", "32.3", " ", "feet", ",", " ", "right", "?", " ", "brr", ",", " ", "it'", "s",
         " ", "29.3", "°", "f", "!", " ", "camel", "case", " ", "pascal", "case", " ", "ijsland",
-        " ", "case",
+        " ", "case", " ", "resume", "writer",
     ];
 
     test_segmenter!(LatinSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Latin, Language::Other);

--- a/charabia/src/segmenter/latin.rs
+++ b/charabia/src/segmenter/latin.rs
@@ -23,18 +23,17 @@ impl Segmenter for LatinSegmenter {
 mod test {
     use crate::segmenter::test::test_segmenter;
 
-    const TEXT: &str = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F! camelCase PascalCase IJsland CASE resuméWriter";
+    const TEXT: &str =
+        "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F! camelCase";
     const SEGMENTED: &[&str] = &[
         "The", " ", "quick", " ", "(", "\"", "brown", "\"", ")", " ", "fox", " ", "can'", "t", " ",
         "jump", " ", "32.3", " ", "feet", ",", " ", "right", "?", " ", "Brr", ",", " ", "it'", "s",
-        " ", "29.3", "°", "F", "!", " ", "camel", "Case", " ", "Pascal", "Case", " ", "IJsland",
-        " ", "CASE", " ", "resumé", "Writer",
+        " ", "29.3", "°", "F", "!", " ", "camel", "Case",
     ];
     const TOKENIZED: &[&str] = &[
         "the", " ", "quick", " ", "(", "\"", "brown", "\"", ")", " ", "fox", " ", "can'", "t", " ",
         "jump", " ", "32.3", " ", "feet", ",", " ", "right", "?", " ", "brr", ",", " ", "it'", "s",
-        " ", "29.3", "°", "f", "!", " ", "camel", "case", " ", "pascal", "case", " ", "ijsland",
-        " ", "case", " ", "resume", "writer",
+        " ", "29.3", "°", "f", "!", " ", "camel", "case",
     ];
 
     test_segmenter!(LatinSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Latin, Language::Other);

--- a/charabia/src/segmenter/latin.rs
+++ b/charabia/src/segmenter/latin.rs
@@ -1,5 +1,6 @@
 use unicode_segmentation::UnicodeSegmentation;
 
+#[cfg(feature = "latin-camelcase")]
 use super::camel_case::CamelCaseSegmentation;
 use super::Segmenter;
 
@@ -9,6 +10,13 @@ use super::Segmenter;
 pub struct LatinSegmenter;
 
 impl Segmenter for LatinSegmenter {
+    #[cfg(not(feature = "latin-camelcase"))]
+    fn segment_str<'o>(&self, s: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
+        let lemmas = s.split_word_bounds().flat_map(|lemma| lemma.split_inclusive('\''));
+        Box::new(lemmas)
+    }
+
+    #[cfg(feature = "latin-camelcase")]
     fn segment_str<'o>(&self, s: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
         let lemmas = s
             .split_word_bounds()

--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -18,6 +18,7 @@ pub use thai::ThaiSegmenter;
 use crate::detection::{Detect, Language, Script, StrDetection};
 use crate::token::Token;
 
+mod camel_case;
 #[cfg(feature = "chinese")]
 mod chinese;
 #[cfg(feature = "hebrew")]

--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -18,6 +18,7 @@ pub use thai::ThaiSegmenter;
 use crate::detection::{Detect, Language, Script, StrDetection};
 use crate::token::Token;
 
+#[cfg(feature = "latin-camelcase")]
 mod camel_case;
 #[cfg(feature = "chinese")]
 mod chinese;


### PR DESCRIPTION
## Related issue
#129

## What does this PR do?

To improve recall and to be consistent with snake_case and kebab-case splitting that's already in place, make the Latin Segmenter split words on camelCase boundaries.

Define camelCase boundary as a lowercase letter directly followed by an uppercase one. (The position between them, to be precise.) This treats most cases and avoids the common pitfalls like eg. ALL_CAPS. What is not handled though, are abbreviations within a longer word. Especially in code it's common to write eg. "meiliAPIClient". With this implementation it's split into ["meili", "APIClient"]. Let me know if that's a blocker.

Leverage the Unicode General Categories
https://en.wikipedia.org/wiki/Unicode_character_property#General_Category
and their support in the Regex crate for matching lowercase and uppercase letters.

Put the logic into a separate module and expose API similar to UnicodeSegmentation's to keep the call-site in latin.rs clean and concise.

Fixes #129.

## Performance
I benchmarked this locally on my Apple-silicon MB Air with `cargo bench` and saw some significant regressions. The  `Latin/Fra` and `Latin/Eng` (in both `132` and `363` variants) regressed some 40% compared to a3eab3067742ab5a0f5570b6fcc242808883a95c. (Here's the full [report](https://github.com/meilisearch/charabia/files/10559955/report.zip)) I'm not sure how big of a problem this is. There definitely are many optimization opportunities but I wanted to propose the simplest solution first and eventually iterate from there.

---

PS: This is my very first rust contribution. Sorry for missing any conventions or leaving in rough edges.

