### PR TITLE
Upgrade Lindera and use compressed dicts

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -22,7 +22,9 @@ serde = "1.0"
 slice-group-by = "0.3.0"
 unicode-segmentation = "1.6.0"
 whatlang = "0.16.1"
-lindera = { version = "=0.17.0", default-features = false, optional = true }
+lindera = { version = "=0.21.0", default-features = false, optional = true }
+lindera-ko-dic = { version = "0.21.0", default-features = false, optional = true }
+lindera-ipadic = { version = "0.21.0", default-features = false, optional = true }
 pinyin = { version = "0.9", default-features = false, features = [
   "with_tone",
 ], optional = true }
@@ -40,11 +42,11 @@ chinese = ["dep:pinyin", "dep:jieba-rs"]
 hebrew = []
 
 # allow japanese specialized tokenization
-japanese = ["lindera/ipadic"]
+japanese = ["lindera/ipadic", "lindera-ipadic/compress"]
 japanese-transliteration = ["dep:wana_kana"]
 
 # allow korean specialized tokenization
-korean = ["lindera/ko-dic"]
+korean = ["lindera/ko-dic", "lindera-ko-dic/compress"]
 
 # allow thai specialized tokenization
 thai = []

--- a/charabia/src/segmenter/korean.rs
+++ b/charabia/src/segmenter/korean.rs
@@ -1,5 +1,6 @@
 use lindera::mode::{Mode, Penalty};
-use lindera::tokenizer::{DictionaryConfig, DictionaryKind, Tokenizer, TokenizerConfig};
+use lindera::tokenizer::{DictionaryConfig, Tokenizer, TokenizerConfig};
+use lindera::DictionaryKind;
 use once_cell::sync::Lazy;
 
 use crate::segmenter::Segmenter;
@@ -11,17 +12,19 @@ pub struct KoreanSegmenter;
 
 static LINDERA: Lazy<Tokenizer> = Lazy::new(|| {
     let config = TokenizerConfig {
-        dictionary: DictionaryConfig { kind: DictionaryKind::KoDic, path: None },
+        dictionary: DictionaryConfig { kind: Some(DictionaryKind::KoDic), path: None },
         mode: Mode::Decompose(Penalty::default()),
         ..TokenizerConfig::default()
     };
-    Tokenizer::with_config(config).unwrap()
+    Tokenizer::from_config(config).unwrap()
 });
 
 impl Segmenter for KoreanSegmenter {
     fn segment_str<'o>(&self, to_segment: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
         let segment_iterator = LINDERA.tokenize(to_segment).unwrap();
-        Box::new(segment_iterator.into_iter().map(|token| token.text))
+        Box::new(
+            segment_iterator.into_iter().map(|token| &to_segment[token.byte_start..token.byte_end]),
+        )
     }
 }
 


### PR DESCRIPTION
Upgrade lindera to the last version and use the compressed dictionary reducing the size of a dummy binary from 209MB
to 44MB.

related to #151
