### PR TITLE
add tatweel normalizer

### DIFF
--- a/charabia/src/normalizer/arabic.rs
+++ b/charabia/src/normalizer/arabic.rs
@@ -1,0 +1,148 @@
+use super::{CharNormalizer, CharOrStr};
+use crate::{Token, Script};
+
+/// A global [`Normalizer`] removing the arabic Tatweel ('ـ') characters.
+/// https://www.compart.com/en/unicode/U+0640
+/// https://en.wikipedia.org/wiki/Kashida
+pub struct ArabicNormalizer;
+
+impl CharNormalizer for ArabicNormalizer {
+    fn normalize_char(&self, c: char) -> Option<CharOrStr> {
+        (!is_tatweel(c)).then(|| c.into())
+    }
+
+    fn should_normalize(&self, token: &Token) -> bool {
+        token.script == Script::Arabic && 
+                        token.lemma().chars().any(is_tatweel)
+    }
+}
+
+fn is_tatweel(c: char) -> bool {
+    c == 'ـ'
+}
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow::Owned;
+
+    use crate::normalizer::test::test_normalizer;
+    use crate::normalizer::{Normalizer, NormalizerOption};
+
+    // base tokens to normalize.
+    fn tokens() -> Vec<Token<'static>> {
+        vec![Token {
+            lemma: Owned("الحمــــــد".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Arabic,
+            ..Default::default()
+        },
+        Token {
+            lemma: Owned("رحــــــيم".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Arabic,
+            char_map: Some(vec![
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2)
+            ]),
+            ..Default::default()
+        }]
+    }
+
+    // expected result of the current Normalizer.
+    fn normalizer_result() -> Vec<Token<'static>> {
+        vec![Token {
+            lemma: Owned("الحمد".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Arabic,
+            char_map: Some(vec![
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0), 
+                (2, 2)
+            ]),
+            ..Default::default()
+        },
+        Token {
+            lemma: Owned("رحيم".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Arabic,
+            char_map: Some(vec![
+                (2, 2),
+                (2, 2),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 2),
+                (2, 2)
+            ]),
+            ..Default::default()
+        }]
+    }
+
+    // expected result of the complete Normalizer pieline.
+    fn normalized_tokens() -> Vec<Token<'static>> {
+        vec![Token {
+            lemma: Owned("الحمد".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            char_map: Some(vec![
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 2),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 2)
+            ]),
+            script: Script::Arabic,
+            ..Default::default()
+        },
+        Token {
+            lemma: Owned("رحيم".to_string()),
+            char_end: 10,
+            byte_end: 10,
+            script: Script::Arabic,
+            char_map: Some(vec![
+                (2, 2),
+                (2, 2),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 0),
+                (2, 2),
+                (2, 2)
+            ]),
+            ..Default::default()
+        }]
+    }
+
+    test_normalizer!(ArabicNormalizer, tokens(), normalizer_result(), normalized_tokens());
+}

--- a/charabia/src/normalizer/mod.rs
+++ b/charabia/src/normalizer/mod.rs
@@ -13,6 +13,7 @@ use crate::classifier::ClassifiedTokenIter;
 use crate::normalizer::nonspacing_mark::NonspacingMarkNormalizer;
 use crate::normalizer::greek::GreekNormalizer;
 use crate::Token;
+pub use self::arabic::ArabicNormalizer;
 
 #[cfg(feature = "chinese")]
 mod chinese;
@@ -24,6 +25,7 @@ mod japanese;
 mod greek;
 mod lowercase;
 mod nonspacing_mark;
+mod arabic;
 
 /// List of [`Normalizer`]s used by [`Normalize::normalize`].
 pub static NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
@@ -38,6 +40,7 @@ pub static NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
         Box::new(GreekNormalizer),
         Box::new(ControlCharNormalizer),
         Box::new(NonspacingMarkNormalizer),
+        Box::new(ArabicNormalizer)
     ]
 });
 


### PR DESCRIPTION
# Pull Request
Adds normalizer to remove arabic Tatweel character

## Related issue
Fixes #186

## What does this PR do?
Adds normalizer to remove arabic Tatweel character
https://en.wikipedia.org/wiki/Kashida
https://www.compart.com/en/unicode/U+0640

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
