### PR TITLE
Regularly check for kVariant updates

### DIFF
--- a/.github/workflows/update-kvariants.yml
+++ b/.github/workflows/update-kvariants.yml
@@ -1,0 +1,29 @@
+name: Check for kVariants updates
+
+on:
+  # Run this at 10:00 every monday.
+  schedule:
+    - cron:  '0 10 * * 1'
+  # Also allow triggering manually.
+  workflow_dispatch:
+
+env:
+  # Use a token that has write access to repo.
+  GH_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
+
+jobs:
+  check-for-kvariants-updates:
+    name: Check for kVariants updates
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Fetch latest version
+        run: ./kvariants/bin/sync_dictionaries.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Update kVariants dictionary
+          branch: update-kvariants
+          title: Update kVariants dictionary
+          body: Automatically created by [scheduled action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/update-kvariants.yml
+++ b/.github/workflows/update-kvariants.yml
@@ -1,4 +1,8 @@
-name: Check for kVariants updates
+name: Update kVariants dictionary
+
+# This workflow regularly looks for updates of the kVariants dictionary
+# in https://github.com/hfhchan/irg and if there are any, it creates
+# a PR with the changes.
 
 on:
   # Run this at 10:00 every monday.
@@ -12,8 +16,8 @@ env:
   GH_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
 
 jobs:
-  check-for-kvariants-updates:
-    name: Check for kVariants updates
+  update-kvariants-dictionary:
+    name: Update kVariants dictionary
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
Related issue: #185

Add a workflow that checks if there are any updates to the kVariants dictionary mirrored from https://github.com/hfhchan/irg and in such case submit a PR.

Schedule it to run at 10:00 every Monday but also allow it to be triggered manually.

An example of a run can be seen [here](https://github.com/goodhoko/charabia/actions/runs/4188213705/jobs/7259060086) and the resulting (testing) PR over [here](https://github.com/goodhoko/charabia/pull/1) (note: the diff set is empty because the artificial change I introduced for testing has since been reverted).

Closes #185.
