### PR TITLE
Fix compilation with no default features

### DIFF
--- a/charabia/src/normalizer/mod.rs
+++ b/charabia/src/normalizer/mod.rs
@@ -11,6 +11,7 @@ pub use self::control_char::ControlCharNormalizer;
 pub use self::japanese::JapaneseNormalizer;
 pub use self::lowercase::LowercaseNormalizer;
 use crate::classifier::ClassifiedTokenIter;
+#[cfg(feature = "greek")]
 use crate::normalizer::greek::GreekNormalizer;
 use crate::normalizer::nonspacing_mark::NonspacingMarkNormalizer;
 use crate::Token;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #201 

## What does this PR do?
- Disable imports of `normalizer::greek` when the `greek` feature is disabled (and thus the module).

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
