### PR TITLE
Update Lindera to 0.24.0

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -23,7 +23,9 @@ serde = "1.0"
 slice-group-by = "0.3.0"
 unicode-segmentation = "1.10.1"
 whatlang = "0.16.2"
-lindera = { version = "=0.23.1", default-features = false, optional = true }
+lindera-core = "=0.24.0"
+lindera-dictionary = "=0.24.0"
+lindera-tokenizer = { version = "=0.24.0", default-features = false, optional = true }
 pinyin = { version = "0.9", default-features = false, features = [
   "with_tone",
 ], optional = true }
@@ -41,11 +43,11 @@ chinese = ["dep:pinyin", "dep:jieba-rs"]
 hebrew = []
 
 # allow japanese specialized tokenization
-japanese = ["lindera/ipadic", "lindera/ipadic-compress"]
+japanese = ["lindera-tokenizer/ipadic", "lindera-tokenizer/ipadic-compress"]
 japanese-transliteration = ["dep:wana_kana"]
 
 # allow korean specialized tokenization
-korean = ["lindera/ko-dic", "lindera/ko-dic-compress"]
+korean = ["lindera-tokenizer/ko-dic", "lindera-tokenizer/ko-dic-compress"]
 
 # allow thai specialized tokenization
 thai = []

--- a/charabia/src/segmenter/japanese.rs
+++ b/charabia/src/segmenter/japanese.rs
@@ -1,7 +1,6 @@
-use lindera::dictionary::DictionaryConfig;
-use lindera::mode::{Mode, Penalty};
-use lindera::tokenizer::{Tokenizer, TokenizerConfig};
-use lindera::DictionaryKind;
+use lindera_core::mode::{Mode, Penalty};
+use lindera_dictionary::{DictionaryConfig, DictionaryKind};
+use lindera_tokenizer::tokenizer::{Tokenizer, TokenizerConfig};
 use once_cell::sync::Lazy;
 
 use crate::segmenter::Segmenter;

--- a/charabia/src/segmenter/korean.rs
+++ b/charabia/src/segmenter/korean.rs
@@ -1,7 +1,6 @@
-use lindera::dictionary::DictionaryConfig;
-use lindera::mode::{Mode, Penalty};
-use lindera::tokenizer::{Tokenizer, TokenizerConfig};
-use lindera::DictionaryKind;
+use lindera_core::mode::{Mode, Penalty};
+use lindera_dictionary::{DictionaryConfig, DictionaryKind};
+use lindera_tokenizer::tokenizer::{Tokenizer, TokenizerConfig};
 use once_cell::sync::Lazy;
 
 use crate::segmenter::Segmenter;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Update Lindera to 0.24.0. In the new Lindera, the Tokenizer and the experimental Analyzer have been separated from the lindera crate.
Meilisearch can now use only the necessary Tokenizer and not include unnecessary features.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
