### PR TITLE
Handle underscore similarly to dash

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -34,7 +34,7 @@ unicode-normalization = "0.1.22"
 irg-kvariants = "0.1.0"
 
 [features]
-default = ["chinese", "hebrew", "japanese", "thai", "korean", "greek", "latin-camelcase"]
+default = ["chinese", "hebrew", "japanese", "thai", "korean", "greek", "latin-camelcase", "latin-snakecase"]
 
 # allow chinese specialized tokenization
 chinese = ["dep:pinyin", "dep:jieba-rs"]
@@ -57,6 +57,9 @@ greek = []
 
 # allow splitting camelCase latin words
 latin-camelcase = ["dep:finl_unicode"]
+
+# allow splitting snake_case latin words
+latin-snakecase = ["dep:finl_unicode"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/charabia/src/segmenter/latin/camel_case.rs
+++ b/charabia/src/segmenter/latin/camel_case.rs
@@ -6,10 +6,7 @@ use slice_group_by::StrGroupBy;
 /// A camelCase boundary constitutes a lowercase letter directly followed by an uppercase letter
 /// optionally with any number of non-spacing marks in between.
 pub(crate) fn split_camel_case_bounds(str: &str) -> impl Iterator<Item = &str> {
-    let mut last_char_was_lowercase = match str.chars().next() {
-        None => false,
-        Some(c) => c.is_letter_lowercase(),
-    };
+    let mut last_char_was_lowercase = str.chars().next().map_or(false, |c| c.is_lowercase());
 
     str.linear_group_by(move |_, char| {
         if char.is_mark_nonspacing() {

--- a/charabia/src/segmenter/latin/mod.rs
+++ b/charabia/src/segmenter/latin/mod.rs
@@ -1,8 +1,11 @@
+#[cfg(feature = "latin-camelcase")]
+mod camel_case;
+#[cfg(feature = "latin-snakecase")]
+mod snake_case;
+
 use unicode_segmentation::UnicodeSegmentation;
 
-#[cfg(feature = "latin-camelcase")]
-use super::camel_case::split_camel_case_bounds;
-use super::Segmenter;
+use crate::segmenter::Segmenter;
 
 /// Latin specialized [`Segmenter`].
 ///
@@ -18,10 +21,14 @@ impl Segmenter for LatinSegmenter {
 
     #[cfg(feature = "latin-camelcase")]
     fn segment_str<'o>(&self, s: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
-        let lemmas = s
-            .split_word_bounds()
-            .flat_map(|lemma| lemma.split_inclusive(['\'', '’', '‘', '‛']))
-            .flat_map(split_camel_case_bounds);
+        let lemmas =
+            s.split_word_bounds().flat_map(|lemma| lemma.split_inclusive(['\'', '’', '‘', '‛']));
+
+        #[cfg(feature = "latin-camelcase")]
+        let lemmas = lemmas.flat_map(camel_case::split_camel_case_bounds);
+
+        #[cfg(feature = "latin-snakecase")]
+        let lemmas = lemmas.flat_map(snake_case::split_snake_case_bounds);
 
         Box::new(lemmas)
     }
@@ -32,16 +39,18 @@ mod test {
     use crate::segmenter::test::test_segmenter;
 
     const TEXT: &str =
-        "The quick (\"brown\") fox can’t jump 32.3 feet, right? Brr, it's 29.3°F! camelCase";
+        "The quick (\"brown\") fox can’t jump 32.3 feet, right? Brr, it's 29.3°F! camelCase kebab-case snake_case";
     const SEGMENTED: &[&str] = &[
         "The", " ", "quick", " ", "(", "\"", "brown", "\"", ")", " ", "fox", " ", "can’", "t", " ",
         "jump", " ", "32.3", " ", "feet", ",", " ", "right", "?", " ", "Brr", ",", " ", "it'", "s",
-        " ", "29.3", "°", "F", "!", " ", "camel", "Case",
+        " ", "29.3", "°", "F", "!", " ", "camel", "Case", " ", "kebab", "-", "case", " ", "snake",
+        "_", "case",
     ];
     const TOKENIZED: &[&str] = &[
         "the", " ", "quick", " ", "(", "\"", "brown", "\"", ")", " ", "fox", " ", "can'", "t", " ",
         "jump", " ", "32.3", " ", "feet", ",", " ", "right", "?", " ", "brr", ",", " ", "it'", "s",
-        " ", "29.3", "°", "f", "!", " ", "camel", "case",
+        " ", "29.3", "°", "f", "!", " ", "camel", "case", " ", "kebab", "-", "case", " ", "snake",
+        "_", "case",
     ];
 
     test_segmenter!(LatinSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Latin, Language::Other);

--- a/charabia/src/segmenter/latin/snake_case.rs
+++ b/charabia/src/segmenter/latin/snake_case.rs
@@ -1,0 +1,74 @@
+use finl_unicode::categories::CharacterCategories;
+use slice_group_by::StrGroupBy;
+
+/// Returns an iterator over substrings of `str` separated on snake_case boundaries.
+/// For instance, "snake_case" is split into ["snake", "_", "case"].
+pub(crate) fn split_snake_case_bounds(str: &str) -> impl Iterator<Item = &str> {
+    let mut last_char_was_underscore =
+        str.chars().next().map_or(false, |c| c.is_punctuation_connector());
+
+    str.linear_group_by(move |_, c| {
+        let same_group =
+            c.is_mark_nonspacing() || last_char_was_underscore == c.is_punctuation_connector();
+        if !same_group {
+            last_char_was_underscore = c.is_punctuation_connector();
+        }
+        same_group
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    macro_rules! test_segmentation {
+        ($text:expr, $segmented:expr, $name:ident) => {
+            #[test]
+            fn $name() {
+                let segmented_text: Vec<_> = split_snake_case_bounds($text).collect();
+                assert_eq!(segmented_text, $segmented);
+            }
+        };
+    }
+
+    test_segmentation!("a", ["a"], one_letter_is_preserved);
+    test_segmentation!("_", ["_"], one_underscore_is_preserved);
+    test_segmentation!("__", ["__"], sequence_of_underscores_is_preserved);
+    test_segmentation!("snake_case", ["snake", "_", "case"], snake_case_is_split);
+    test_segmentation!("kebab-case", ["kebab-case"], kebab_case_is_preserved);
+    test_segmentation!(
+        "SCREAMING_SNAKE_CASE",
+        ["SCREAMING", "_", "SNAKE", "_", "CASE"],
+        screaming_snake_case_is_split
+    );
+    test_segmentation!("resumé_writer", ["resumé", "_", "writer"], non_ascii_boundary_on_left);
+    test_segmentation!("Karel_Čapek", ["Karel", "_", "Čapek"], non_ascii_boundary_on_right);
+    test_segmentation!("a\u{0301}_b", ["a\u{0301}", "_", "b"], non_spacing_mark_on_left);
+    test_segmentation!("a_\u{0301}b", ["a", "_\u{0301}", "b"], non_spacing_mark_on_right);
+    test_segmentation!(
+        "a\u{0301}_\u{0301}b",
+        ["a\u{0301}", "_\u{0301}", "b"],
+        non_spacing_marks_on_both_sides
+    );
+    test_segmentation!("_\u{0301}_", ["_\u{0301}_"], non_spacing_mark_between_underscores);
+    test_segmentation!(
+        "a\u{0301}_",
+        ["a\u{0301}", "_"],
+        non_spacing_mark_between_letter_and_underscore
+    );
+    test_segmentation!(
+        "_\u{0301}b",
+        ["_\u{0301}", "b"],
+        non_spacing_mark_between_underscore_and_letter
+    );
+    test_segmentation!(
+        "__double_leading_underscore",
+        ["__", "double", "_", "leading", "_", "underscore"],
+        double_leading_underscore
+    );
+    test_segmentation!(
+        "__double_leading_and_trailing_underscore__",
+        ["__", "double", "_", "leading", "_", "and", "_", "trailing", "_", "underscore", "__"],
+        double_leading_and_trailing_underscore
+    );
+}

--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -20,8 +20,6 @@ use crate::detection::{Detect, Language, Script, StrDetection};
 use crate::token::Token;
 
 mod arabic;
-#[cfg(feature = "latin-camelcase")]
-mod camel_case;
 #[cfg(feature = "chinese")]
 mod chinese;
 #[cfg(feature = "hebrew")]


### PR DESCRIPTION
Ensure that `LatinSegmenter` treats `'_'` and `'-'` similarly.

```rust
let text = "kebab-case snake_case";
let lemmas = LatinSegmenter.segment_str(text).collect::<Vec<_>>();

// // Before:
// assert_eq!(lemmas, vec!["kebab", "-", "case", " ", "snake_case"]);

// After:
assert_eq!(lemmas, vec!["kebab", "-", "case", " ", "snake", "_", "case"]);
```

Fixes meilisearch/meilisearch#3320

## Performance impact

<details>
<summary>Performance has regressed</summary>

```
segment/132/Cj/Cmn      time:   [4.8455 µs 4.8529 µs 4.8603 µs]
                        change: [+0.2291% +0.4606% +0.6544%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
segment/132/Cj/Jpn      time:   [11.873 µs 11.938 µs 12.021 µs]
                        change: [+2.2313% +2.5565% +2.9079%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
segment/132/Latin/Eng   time:   [4.5341 µs 4.5535 µs 4.5758 µs]
                        change: [+6.5566% +7.1359% +7.7580%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild
segment/132/Latin/Fra   time:   [4.0289 µs 4.0612 µs 4.0918 µs]
                        change: [+6.6098% +7.1420% +7.7122%] (p = 0.00 < 0.05)
                        Performance has regressed.
segment/132/Hebrew/Heb  time:   [2.0973 µs 2.1029 µs 2.1092 µs]
                        change: [+0.8029% +1.1487% +1.4954%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
segment/132/Thai/Tha    time:   [2.9620 µs 2.9732 µs 2.9849 µs]
                        change: [-0.1291% +0.1980% +0.5083%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  9 (9.00%) high mild
segment/132/Hangul/Kor  time:   [28.454 µs 28.510 µs 28.569 µs]
                        change: [+0.5761% +0.8170% +1.0582%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
segment/130/Greek/Ell   time:   [2.7629 µs 2.7671 µs 2.7720 µs]
                        change: [+3.5064% +3.8427% +4.1407%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
segment/132/Arabic/Ara  time:   [2.0159 µs 2.0224 µs 2.0287 µs]
                        change: [+0.8583% +1.1485% +1.4483%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 29 outliers among 100 measurements (29.00%)
  11 (11.00%) low severe
  11 (11.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
segment/363/Cj/Cmn      time:   [16.565 µs 16.587 µs 16.616 µs]
                        change: [+2.3711% +2.6112% +2.8248%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
segment/364/Cj/Jpn      time:   [33.895 µs 33.926 µs 33.961 µs]
                        change: [+0.0372% +0.3133% +0.5825%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  10 (10.00%) high mild
  6 (6.00%) high severe
segment/363/Latin/Eng   time:   [11.272 µs 11.293 µs 11.313 µs]
                        change: [+6.0697% +6.4038% +6.7377%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 21 outliers among 100 measurements (21.00%)
  5 (5.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  12 (12.00%) high severe
segment/363/Latin/Fra   time:   [11.386 µs 11.409 µs 11.433 µs]
                        change: [+7.3128% +7.6566% +8.0077%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
segment/365/Hebrew/Heb  time:   [5.6753 µs 5.6928 µs 5.7102 µs]
                        change: [+2.1924% +2.5472% +2.8979%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 23 outliers among 100 measurements (23.00%)
  7 (7.00%) low severe
  7 (7.00%) high mild
  9 (9.00%) high severe
segment/366/Thai/Tha    time:   [6.8448 µs 6.8533 µs 6.8630 µs]
                        change: [-1.1688% -0.8596% -0.5327%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  7 (7.00%) high mild
  9 (9.00%) high severe
segment/364/Hangul/Kor  time:   [66.096 µs 66.168 µs 66.255 µs]
                        change: [-0.4412% -0.2486% -0.0464%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe
segment/364/Greek/Ell   time:   [8.3153 µs 8.3370 µs 8.3639 µs]
                        change: [+5.2614% +5.7158% +6.1305%] (p = 0.00 < 0.05)
                        Performance has regressed.
segment/366/Arabic/Ara  time:   [6.2222 µs 6.2304 µs 6.2393 µs]
                        change: [+0.0931% +0.5747% +1.0276%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  13 (13.00%) high severe

tokenize/132/Cj/Cmn     time:   [9.6537 µs 9.6647 µs 9.6776 µs]
                        change: [+1.3939% +1.7514% +2.1068%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
tokenize/132/Cj/Jpn     time:   [14.387 µs 14.399 µs 14.412 µs]
                        change: [-0.4105% -0.1183% +0.1653%] (p = 0.43 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
tokenize/132/Latin/Eng  time:   [7.7199 µs 7.7288 µs 7.7392 µs]
                        change: [+0.3354% +0.7214% +1.1148%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low mild
  10 (10.00%) high mild
  6 (6.00%) high severe
tokenize/132/Latin/Fra  time:   [8.4963 µs 8.5065 µs 8.5174 µs]
                        change: [+0.7393% +1.0216% +1.3274%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  12 (12.00%) high severe
tokenize/132/Hebrew/Heb time:   [5.8861 µs 5.8925 µs 5.8998 µs]
                        change: [-0.6397% -0.3438% -0.0277%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  4 (4.00%) high severe
tokenize/132/Thai/Tha   time:   [5.2707 µs 5.2784 µs 5.2866 µs]
                        change: [-0.7710% -0.3804% +0.0088%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) low severe
  4 (4.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
tokenize/132/Hangul/Kor time:   [34.889 µs 34.915 µs 34.945 µs]
                        change: [-0.6621% -0.3845% -0.1076%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
tokenize/130/Greek/Ell  time:   [7.8502 µs 7.8573 µs 7.8656 µs]
                        change: [+0.7264% +1.0847% +1.4311%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  10 (10.00%) high mild
  4 (4.00%) high severe
tokenize/132/Arabic/Ara time:   [5.6077 µs 5.6151 µs 5.6235 µs]
                        change: [-0.3392% -0.0693% +0.1950%] (p = 0.62 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
tokenize/363/Cj/Cmn     time:   [29.313 µs 29.341 µs 29.374 µs]
                        change: [+1.3307% +1.5489% +1.7554%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
tokenize/364/Cj/Jpn     time:   [40.557 µs 40.599 µs 40.647 µs]
                        change: [-1.0438% -0.7569% -0.4808%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
tokenize/363/Latin/Eng  time:   [19.285 µs 19.310 µs 19.339 µs]
                        change: [+0.8779% +1.2027% +1.5248%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
tokenize/363/Latin/Fra  time:   [22.490 µs 22.511 µs 22.533 µs]
                        change: [+2.5026% +2.7096% +2.9121%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
tokenize/365/Hebrew/Heb time:   [15.790 µs 15.810 µs 15.834 µs]
                        change: [-1.0931% -0.8949% -0.6881%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe
tokenize/366/Thai/Tha   time:   [13.566 µs 13.583 µs 13.602 µs]
                        change: [-0.9275% -0.6499% -0.3743%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  6 (6.00%) high mild
  7 (7.00%) high severe
tokenize/364/Hangul/Kor time:   [84.607 µs 84.687 µs 84.783 µs]
                        change: [-1.2843% -0.9747% -0.6813%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 19 outliers among 100 measurements (19.00%)
  7 (7.00%) high mild
  12 (12.00%) high severe
tokenize/364/Greek/Ell  time:   [24.110 µs 24.140 µs 24.173 µs]
                        change: [-0.6253% -0.3232% -0.0097%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
tokenize/366/Arabic/Ara time:   [17.013 µs 17.040 µs 17.069 µs]
                        change: [+0.0311% +0.3013% +0.5689%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  9 (9.00%) high mild
  5 (5.00%) high severe
```

</details>

This is to be expected, given that we are iterating over each string slice several times.

```rust
fn segment_str<'o>(s: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
    let lemmas = s
        .split_word_bounds()
        .flat_map(|lemma| lemma.split_inclusive(['\'', '’', '‘', '‛']))
        .flat_map(split_camel_case_bounds)
        .flat_map(split_snake_case_bounds);

    Box::new(lemmas)
}
```

