### PR TITLE
Remove colon from hard separators

### DIFF
--- a/charabia/src/separators.rs
+++ b/charabia/src/separators.rs
@@ -65,7 +65,7 @@ pub const DEFAULT_SEPARATORS: &[&str] = &[
 pub const CONTEXT_SEPARATORS: &[&str] = &[
     "᠆", // Mongolian Todo Soft Hyphen, mark the end of a paragraph.
     "᚛", "᚜", // Oghams, mark start and end of text
-    "!", ". ", ", ", ":", ";", "?", "¡", "§", "¶", "¿", ";", // Latin
+    "!", ". ", ", ", ";", "?", "¡", "§", "¶", "¿", ";", // Latin
     "՜", // Armenian exclamation mark
     "՝", // Armenian comma
     "՞", // Armenian question mark


### PR DESCRIPTION
The colon character is not meant to be in the context separator's list,
it's mainly used to make the link between two things and not to separate two different contexts.


