### PR TITLE
Fix pre-segmenter when a string start by an uncategorized character

### DIFF
--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -123,12 +123,18 @@ pub struct SegmentedStrIter<'o, 'tb> {
 impl<'o, 'tb> SegmentedStrIter<'o, 'tb> {
     pub fn new(original: &'o str, options: &'tb SegmenterOption<'tb>) -> Self {
         let mut current_script = Script::Other;
+        let mut group_id = 0;
         let inner = original.linear_group_by_key(move |c| {
             let script = Script::from(c);
             if script != Script::Other && script != current_script {
+                // if both previous and current scripts are differents than Script::Other,
+                // split into a new script group.
+                if current_script != Script::Other {
+                    group_id += 1;
+                }
                 current_script = script
             }
-            current_script
+            group_id
         });
 
         Self {


### PR DESCRIPTION
When a field start with an uncategorized character like numbers these characters will be put in a separate group from the first categorized character which gives a different segmentation on the same word. For example, a field containing `Memory 96GB` will be split as `["Memory", " ", "96GB"]` and a query containing `96GB` will be split as `["96", "GB"]` because `96` is uncategorized where `GB` is `Latin`. Now we ensure to group every uncategorized character with the next script.

related to https://github.com/meilisearch/meilisearch/discussions/3924#discussioncomment-6468493