### PR TITLE
Remap the char map when lowercasing strings

### DIFF
--- a/charabia/src/normalizer/classify.rs
+++ b/charabia/src/normalizer/classify.rs
@@ -48,7 +48,7 @@ impl Normalizer for Classifier {
 }
 
 /// Structure for providing options to the classfier.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ClassifierOption<'no> {
     pub stop_words: Option<Set<&'no [u8]>>,
     pub separators: Option<&'no [&'no str]>,

--- a/charabia/src/normalizer/lowercase.rs
+++ b/charabia/src/normalizer/lowercase.rs
@@ -15,24 +15,18 @@ impl Normalizer for LowercaseNormalizer {
     fn normalize<'o>(&self, mut token: Token<'o>, _options: &NormalizerOption) -> Token<'o> {
         match token.char_map.take() {
             Some(char_map) => {
-                // Most of the time lowercasing a string will not change it's length
-                let lowercased = token.lemma.to_lowercase();
-                if token.lemma.len() == lowercased.len() {
-                    token.lemma = Cow::Owned(lowercased);
-                } else {
-                    let mut new_lemma = String::new(); // with_capacity?
-                    let mut new_char_map = Vec::with_capacity(char_map.len());
-                    let mut s = token.lemma.as_ref();
-                    for (orig_len, new_len) in char_map {
-                        let (chunk, tail) = s.split_at(new_len as usize);
-                        s = tail;
-                        let lowercased_chunk = chunk.to_lowercase();
-                        new_char_map.push((orig_len, lowercased_chunk.len() as u8));
-                        new_lemma.push_str(&lowercased_chunk);
-                    }
-                    token.char_map = Some(new_char_map);
-                    token.lemma = Cow::Owned(new_lemma);
+                let mut new_lemma = String::with_capacity(token.lemma.len());
+                let mut new_char_map = Vec::with_capacity(char_map.len());
+                let mut s = token.lemma.as_ref();
+                for (orig_len, new_len) in char_map {
+                    let (chunk, tail) = s.split_at(new_len as usize);
+                    s = tail;
+                    let lowercased_chunk = chunk.to_lowercase();
+                    new_char_map.push((orig_len, lowercased_chunk.len() as u8));
+                    new_lemma.push_str(&lowercased_chunk);
                 }
+                token.lemma = Cow::Owned(new_lemma);
+                token.char_map = Some(new_char_map);
             }
             None => token.lemma = Cow::Owned(token.lemma().to_lowercase()),
         }

--- a/charabia/src/normalizer/lowercase.rs
+++ b/charabia/src/normalizer/lowercase.rs
@@ -9,10 +9,33 @@ use crate::Token;
 pub struct LowercaseNormalizer;
 
 impl Normalizer for LowercaseNormalizer {
-    // lowercasing characters doesn't change the characters length,
-    // so the `normalize` method is overloaded to skip the useless char_map computing.
+    // lowercasing characters cna change the characters length, so we need
+    // to make sure that the char mapping is correct and remap it if necessary.
+    // <https://github.com/meilisearch/charabia/pull/234>
     fn normalize<'o>(&self, mut token: Token<'o>, _options: &NormalizerOption) -> Token<'o> {
-        token.lemma = Cow::Owned(token.lemma().to_lowercase());
+        match token.char_map.take() {
+            Some(char_map) => {
+                // Most of the time lowercasing a string will not change it's length
+                let lowercased = token.lemma.to_lowercase();
+                if token.lemma.len() == lowercased.len() {
+                    token.lemma = Cow::Owned(lowercased);
+                } else {
+                    let mut new_lemma = String::new(); // with_capacity?
+                    let mut new_char_map = Vec::with_capacity(char_map.len());
+                    let mut s = token.lemma.as_ref();
+                    for (orig_len, new_len) in char_map {
+                        let (chunk, tail) = s.split_at(new_len as usize);
+                        s = tail;
+                        let lowercased_chunk = chunk.to_lowercase();
+                        new_char_map.push((orig_len, lowercased_chunk.len() as u8));
+                        new_lemma.push_str(&lowercased_chunk);
+                    }
+                    token.char_map = Some(new_char_map);
+                    token.lemma = Cow::Owned(new_lemma);
+                }
+            }
+            None => token.lemma = Cow::Owned(token.lemma().to_lowercase()),
+        }
 
         token
     }

--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -261,7 +261,7 @@ fn segmenter<'b>(detector: &mut StrDetection) -> &'b dyn Segmenter {
 }
 
 /// Structure for providing options to a normalizer.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SegmenterOption<'tb> {
     pub aho: Option<AhoCorasick>,
     pub allow_list: Option<&'tb HashMap<Script, Vec<Language>>>,

--- a/charabia/src/tokenizer.rs
+++ b/charabia/src/tokenizer.rs
@@ -98,6 +98,7 @@ impl Tokenize<'_> for &str {
 /// Structure used to tokenize a text with custom configurations.
 ///
 /// See [`TokenizerBuilder`] to know how to build a [`Tokenizer`].
+#[derive(Debug)]
 pub struct Tokenizer<'tb> {
     segmenter_option: Cow<'tb, SegmenterOption<'tb>>,
     normalizer_option: Cow<'tb, NormalizerOption<'tb>>,
@@ -366,7 +367,7 @@ impl Default for TokenizerBuilder<'_, Vec<u8>> {
 mod test {
     use fst::Set;
 
-    use crate::tokenizer::{Tokenize, TokenizerBuilder};
+    use crate::{Tokenize, TokenizerBuilder};
 
     #[test]
     fn check_lifetimes() {


### PR DESCRIPTION
This PR is related to https://github.com/meilisearch/meilisearch-support/issues/1 and creates a test with a string making, producing a panic. The issue is due to the standard Rust lowercase function not recomputing the char map because it is stated that a lowercase doesn't change the size of the character when, in fact, [it does (stackoverflow)](https://stackoverflow.com/a/69060412/1941280), e.g. [`Ɦ` gives `ɦ`, 3 bytes to 2 bytes](https://mothereff.in/byte-counter#%EA%9E%AA%C9%A6).