### PR TITLE
Fix `update-kvariants` CI

### DIFF
--- a/.github/workflows/update-kvariants.yml
+++ b/.github/workflows/update-kvariants.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Fetch latest version
-        run: ./kvariants/bin/sync_dictionaries.sh
+        run: ./irg-kvariants/bin/sync_dictionaries.sh
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes #254 

## What does this PR do?

Fix the failing CI job [update-kvariants](https://github.com/meilisearch/charabia/actions/workflows/update-kvariants.yml)

According to a failed job [update-kvariants#7445878735](https://github.com/meilisearch/charabia/actions/runs/7445878735/job/20255022744):

```
Run ./kvariants/bin/sync_dictionaries.sh
/home/runner/work/_temp/23998b39-752b-4208-8978-233c8a1d6bc9.sh: line 1: ./kvariants/bin/sync_dictionaries.sh: No such file or directory
Error: Process completed with exit code 127.
```

It's just that the script was renamed during https://github.com/meilisearch/charabia/commit/49ee6919acf7ec676ed79394ac134ee2f533234a#diff-2a8d55e3eb61740bcff85b34a600a97afdc4c49f543e40fe04c5d22a3ff9fc65

<details><summary> also did a simple test of the script locally </summary>

![image](https://github.com/meilisearch/charabia/assets/12410942/b2f609b7-1dbf-45a2-b5f7-879130deeaca)

</details>


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
