### PR TITLE
Fix unused FstSegmenter warning when not using khmer compiler features

### DIFF
--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -35,6 +35,7 @@ mod korean;
 mod latin;
 #[cfg(feature = "thai")]
 mod thai;
+#[cfg(any(feature = "thai", feature = "khmer"))]
 mod utils;
 
 /// List of used [`Segmenter`]s linked to their corresponding [`Script`] and [`Language`].


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes <https://github.com/meilisearch/charabia/issues/260>
Depends on <https://github.com/meilisearch/charabia/pull/259>

## What does this PR do?
- Fixes compilation warnings without `thai` or `khmer` features
- Puts related module behind conditional feature attribute

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
