### PR TITLE
Update wana_kana to 4.0.0

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -26,7 +26,7 @@ lindera = { version = "=0.32.2", default-features = false, optional = true }
 pinyin = { version = "0.10", default-features = false, features = [
   "with_tone",
 ], optional = true }
-wana_kana = { version = "3.0.0", optional = true }
+wana_kana = { version = "4.0.0", optional = true }
 unicode-normalization = "0.1.23"
 irg-kvariants = { path = "../irg-kvariants", version = "=0.1.1" }
 

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -43,7 +43,7 @@ chinese-normalization-pinyin = ["dep:pinyin", "chinese-normalization"]
 hebrew = []
 
 # allow japanese specialized tokenization
-japanese = ["japanese-segmentation-unidic"]
+japanese = ["japanese-segmentation-unidic", "japanese-transliteration"]
 japanese-segmentation-ipadic = ["lindera/ipadic", "lindera/compress"]
 japanese-segmentation-unidic = ["lindera/unidic", "lindera/compress"]
 japanese-transliteration = ["dep:wana_kana"]


### PR DESCRIPTION
# Pull Request

## Related issue

- Fixes #313
- https://github.com/meilisearch/meilisearch/pull/3588#issuecomment-1543840378
- https://github.com/PSeitz/wana_kana_rust/issues/13
- https://github.com/meilisearch/meilisearch/pull/3588/commits/0fbda6383b13170ce04c1bd002c643812d32bb22
- https://github.com/orgs/meilisearch/discussions/532#discussioncomment-9999921

## What does this PR do?

`wana_kana` used to easily panic. The panicability made it difficult to adopt it in the Meilisearch core. Update it to the latest version that [doesn't panic](https://github.com/orgs/meilisearch/discussions/532#discussioncomment-10814507).

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
