### PR TITLE
Adds support for the use of external dictionaries for segmenters backed by lindera

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -46,10 +46,13 @@ hebrew = []
 japanese = ["japanese-segmentation-unidic", "japanese-transliteration"]
 japanese-segmentation-ipadic = ["lindera/ipadic", "lindera/compress"]
 japanese-segmentation-unidic = ["lindera/unidic", "lindera/compress"]
+japanese-segmentation-external = ["lindera/compress"]
 japanese-transliteration = ["dep:wana_kana"]
 
 # allow korean specialized tokenization
-korean = ["lindera/ko-dic", "lindera/compress"]
+korean = ["korean_segmentation_kodic", "lindera/compress"]
+korean_segmentation_kodic = ["lindera/ko-dic"]
+korean_segmentation_external = []
 
 # allow thai specialized tokenization
 thai = []

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -50,7 +50,7 @@ japanese-segmentation-external = ["lindera/compress"]
 japanese-transliteration = ["dep:wana_kana"]
 
 # allow korean specialized tokenization
-korean = ["korean-segmentation-external", "lindera/compress"]
+korean = ["korean-segmentation-kodic", "lindera/compress"]
 korean-segmentation-kodic = ["lindera/ko-dic"]
 korean-segmentation-external = []
 

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -50,8 +50,8 @@ japanese-segmentation-external = ["lindera/compress"]
 japanese-transliteration = ["dep:wana_kana"]
 
 # allow korean specialized tokenization
-korean = ["korean_segmentation_kodic", "lindera/compress"]
-korean_segmentation_kodic = ["lindera/ko-dic"]
+korean = ["korean-segmentation-external", "lindera/compress"]
+korean-segmentation-kodic = ["lindera/ko-dic"]
 korean-segmentation-external = []
 
 # allow thai specialized tokenization

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -52,7 +52,7 @@ japanese-transliteration = ["dep:wana_kana"]
 # allow korean specialized tokenization
 korean = ["korean_segmentation_kodic", "lindera/compress"]
 korean_segmentation_kodic = ["lindera/ko-dic"]
-korean_segmentation_external = []
+korean-segmentation-external = []
 
 # allow thai specialized tokenization
 thai = []

--- a/charabia/src/segmenter/japanese.rs
+++ b/charabia/src/segmenter/japanese.rs
@@ -1,6 +1,13 @@
+use std::{env, path::PathBuf};
+
+#[cfg(any(
+    feature = "japanese-segmentation-ipadic",
+    feature = "japanese-segmentation-unidic"
+))]
+use lindera::DictionaryKind;
 #[cfg(feature = "japanese-segmentation-ipadic")]
 use lindera::Penalty;
-use lindera::{DictionaryConfig, DictionaryKind, Mode, Tokenizer, TokenizerConfig};
+use lindera::{DictionaryConfig, Mode, Tokenizer, TokenizerConfig};
 use once_cell::sync::Lazy;
 
 use crate::segmenter::Segmenter;
@@ -14,6 +21,12 @@ static LINDERA: Lazy<Tokenizer> = Lazy::new(|| {
     #[cfg(all(feature = "japanese-segmentation-ipadic", feature = "japanese-segmentation-unidic"))]
     compile_error!("Feature japanese-segmentation-ipadic and japanese-segmentation-unidic are mutually exclusive and cannot be enabled together");
 
+    #[cfg(all(
+        feature = "japanese-segmentation-external",
+        any(feature = "japanese-segmentation-ipadic", feature = "japanese-segmentation-unidic")
+    ))]
+    compile_error!("Feature japanese-segmentation-external and either japanese-segmentation-unidic or japanese-segmentation-ipadic are mutually exclusive and cannot be enabled together");
+
     #[cfg(feature = "japanese-segmentation-ipadic")]
     let config = TokenizerConfig {
         dictionary: DictionaryConfig { kind: Some(DictionaryKind::IPADIC), path: None },
@@ -26,6 +39,13 @@ static LINDERA: Lazy<Tokenizer> = Lazy::new(|| {
         mode: Mode::Normal,
         ..TokenizerConfig::default()
     };
+    #[cfg(feature = "japanese-segmentation-external")]
+    let config = TokenizerConfig {
+        dictionary: DictionaryConfig { kind: None, path: Some(PathBuf::from(env::var("MEILISEARCH_JAPANESE_EXTERNAL_DICTIONARY").expect("japanese-segmentation-external feature requires MEILISEARCH_JAPANESE_EXTERNAL_DICTIONARY env var to be set"))) },
+        mode: Mode::Normal,
+        ..TokenizerConfig::default()
+    };
+
     Tokenizer::from_config(config).unwrap()
 });
 
@@ -37,6 +57,7 @@ impl Segmenter for JapaneseSegmenter {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "japanese-segmentation-external"))]
 mod test {
     use crate::segmenter::test::test_segmenter;
 

--- a/charabia/src/segmenter/japanese.rs
+++ b/charabia/src/segmenter/japanese.rs
@@ -1,9 +1,6 @@
+#[cfg(feature = "japanese-segmentation-external")]
 use std::{env, path::PathBuf};
-
-#[cfg(any(
-    feature = "japanese-segmentation-ipadic",
-    feature = "japanese-segmentation-unidic"
-))]
+#[cfg(not(feature = "japanese-segmentation-external"))]
 use lindera::DictionaryKind;
 #[cfg(feature = "japanese-segmentation-ipadic")]
 use lindera::Penalty;

--- a/charabia/src/segmenter/korean.rs
+++ b/charabia/src/segmenter/korean.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "korean-segmentation-external")]
 use std::{env, path::PathBuf};
 
 #[cfg(not(feature = "korean-segmentation-external"))]

--- a/charabia/src/segmenter/korean.rs
+++ b/charabia/src/segmenter/korean.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-#[cfg(not(feature = "korean_segmentation_external"))]
+#[cfg(not(feature = "korean-segmentation-external"))]
 use lindera::DictionaryKind;
 
 use lindera::{DictionaryConfig, Mode, Penalty, Tokenizer, TokenizerConfig};
@@ -14,14 +14,14 @@ use crate::segmenter::Segmenter;
 pub struct KoreanSegmenter;
 
 static LINDERA: Lazy<Tokenizer> = Lazy::new(|| {
-    #[cfg(not(feature = "korean_segmentation_external"))]
+    #[cfg(not(feature = "korean-segmentation-external"))]
     let config = TokenizerConfig {
         dictionary: DictionaryConfig { kind: Some(DictionaryKind::KoDic), path: None },
         mode: Mode::Decompose(Penalty::default()),
         ..TokenizerConfig::default()
     };
 
-    #[cfg(feature = "korean_segmentation_external")]
+    #[cfg(feature = "korean-segmentation-external")]
     let config = TokenizerConfig {
         dictionary: DictionaryConfig { kind: None, path: Some(PathBuf::from(env::var("MEILISEARCH_KOREAN_EXTERNAL_DICTIONARY").expect("korean-segmentation-external feature requires MEILISEARCH_KOREAN_EXTERNAL_DICTIONARY env var to be set"))) },
         mode: Mode::Decompose(Penalty::default()),
@@ -39,7 +39,7 @@ impl Segmenter for KoreanSegmenter {
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "korean_segmentation_external"))]
+#[cfg(not(feature = "korean-segmentation-external"))]
 mod test {
     use crate::segmenter::test::test_segmenter;
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes [#322](https://github.com/meilisearch/charabia/issues/322)

## What does this PR do?
- This PR adds the features korean-segmentation-external and japanese-segmentation-external, that allow the user to decouple the download of the japanese and korean dictionaries from the compilation process, and configure the path to already downloaded lindera compatible dictionaries, with the MEILISEARCH_JAPANESE_EXTERNAL_DICTIONARY and MEILISEARCH_KOREAN_EXTERNAL_DICTIONARY env vars.

this PR is **not finished.** Since we cant control which dict the user will use, we cant be sure about the segmentation process, so activating the features will disable segmentation tests for now. Another thing worth mentioning is that for lindera to use an external dict, you need generate it through the lindera CLI. The process isnt exactly obvious and needs to be documented. Its described [here](https://github.com/lindera/lindera/issues/436)
