### PR TITLE
fix: update Lindera to 0.41.0

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -15,14 +15,14 @@ exclude = ["dictionaries/txt/thai/words.txt"]
 aho-corasick = "1.1.3"
 csv = "1.3.1"
 either = "1.13.0"
-finl_unicode = { version= "1.3.0", optional = true }
+finl_unicode = { version = "1.3.0", optional = true }
 fst = "0.4"
 jieba-rs = { version = "0.7", optional = true }
 once_cell = "1.20.2"
 serde = "1.0.217"
 slice-group-by = "0.3.1"
 whatlang = "0.16.4"
-lindera = { version = "=0.32.3", default-features = false, optional = true }
+lindera = { version = "0.41.0", default-features = false, optional = true }
 pinyin = { version = "0.10", default-features = false, features = [
   "with_tone",
 ], optional = true }
@@ -31,7 +31,19 @@ unicode-normalization = "0.1.24"
 irg-kvariants = { path = "../irg-kvariants", version = "=0.1.1" }
 
 [features]
-default = ["chinese", "hebrew", "japanese", "thai", "korean", "greek", "khmer", "vietnamese", "swedish-recomposition", "turkish", "german-segmentation"]
+default = [
+  "chinese",
+  "hebrew",
+  "japanese",
+  "thai",
+  "korean",
+  "greek",
+  "khmer",
+  "vietnamese",
+  "swedish-recomposition",
+  "turkish",
+  "german-segmentation",
+]
 
 # allow chinese specialized tokenization
 chinese = ["chinese-segmentation", "chinese-normalization"]


### PR DESCRIPTION
# Pull Request

Fixes #265 

## What does this PR do?
- This PR updates the `lindera` crate to 0.41.0, as since 0.35 the Lindera project has updated their asset handling so that the crate can compile for WASM. Therefore, it makes it easier to use the charabia tokenizer in Web Assembly.
- Previously I attempted to cross-compile charabia to Linux ARM and faced difficulties due to Lindera's dependency on `ureq` which dependencies on `ring`, a notoriously tricky crate to cross compile. Lindera has since moved to use `reqwest` that doesn't have this problem.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
