### PR TITLE
Bump Lindera to 0.42.1

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -22,9 +22,9 @@ once_cell = "1.20.2"
 serde = "1.0.217"
 slice-group-by = "0.3.1"
 whatlang = "0.16.4"
-lindera = { version = "0.41.0", default-features = false, optional = true }
+lindera = { version = "0.42.1", default-features = false, optional = true }
 pinyin = { version = "0.10", default-features = false, features = [
-  "with_tone",
+    "with_tone",
 ], optional = true }
 wana_kana = { version = "4.0.0", optional = true }
 unicode-normalization = "0.1.24"
@@ -32,17 +32,17 @@ irg-kvariants = { path = "../irg-kvariants", version = "=0.1.1" }
 
 [features]
 default = [
-  "chinese",
-  "hebrew",
-  "japanese",
-  "thai",
-  "korean",
-  "greek",
-  "khmer",
-  "vietnamese",
-  "swedish-recomposition",
-  "turkish",
-  "german-segmentation",
+    "chinese",
+    "hebrew",
+    "japanese",
+    "thai",
+    "korean",
+    "greek",
+    "khmer",
+    "vietnamese",
+    "swedish-recomposition",
+    "turkish",
+    "german-segmentation",
 ]
 
 # allow chinese specialized tokenization


### PR DESCRIPTION
This PR bumps lindera to 0.42.1 [featuring more security when downloading dictionaries](https://github.com/lindera/lindera/pull/481).