### PR TITLE
Secondary cut for Chinese

### DIFF
--- a/charabia/src/segmenter/chinese.rs
+++ b/charabia/src/segmenter/chinese.rs
@@ -50,8 +50,7 @@ impl Segmenter for ChineseSegmenter {
         let segmented: Vec<&str> = JIEBA
             .cut(to_segment, false) // disable Hidden Markov Models.
             .into_iter()
-            .map(|x| cut_for_search(x))
-            .flatten()
+            .flat_map(|x| cut_for_search(x))
             .collect();
         Box::new(segmented.into_iter())
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #338

## What does this PR do?
Refer to `jieba.cut_for_search` to perform a secondary segmentation on the overly long words generated by `jieba.cut`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
