### PR TITLE
Fix jieba-rs requirement

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -17,7 +17,7 @@ csv = "1.3.1"
 either = "1.13.0"
 finl_unicode = { version = "1.3.0", optional = true }
 fst = "0.4"
-jieba-rs = { version = "0.7", optional = true }
+jieba-rs = { version = "0.7.3", optional = true }
 once_cell = "1.20.2"
 serde = "1.0.217"
 slice-group-by = "0.3.1"


### PR DESCRIPTION
Fix build error

```
  --> /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/charabia-0.9.6/src/segmenter/chinese.rs:26:78
   |
26 |         if let Some(bigram) = next_gram::<2>(&s[index..]).filter(|sub| JIEBA.has_word(sub)) {
   |                                                                              ^^^^^^^^ method not found in `Lazy<Jieba>`

error[E0599]: no method named `has_word` found for struct `once_cell::sync::Lazy<Jieba>` in the current scope
  --> /home/agourlay/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/charabia-0.9.6/src/segmenter/chinese.rs:31:86
   |
31 |         } else if let Some(trigram) = next_gram::<3>(&s[index..]).filter(|sub| JIEBA.has_word(sub))
   |                                                                                      ^^^^^^^^ method not found in `Lazy<Jieba>`
```

The `has_word` method has been added in `0.7.2` in `jieba-rs`.
https://github.com/messense/jieba-rs/compare/v0.7.1...v0.7.2

Therefore the requirement from `charabia` must be more precise.

I took `0.7.3` to get the latest current version.