### PR TITLE
Make classification case insenstive

### DIFF
--- a/charabia/src/normalizer/mod.rs
+++ b/charabia/src/normalizer/mod.rs
@@ -55,15 +55,14 @@ pub static NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
         #[cfg(feature = "swedish-recomposition")]
         Box::new(SwedishRecompositionNormalizer),
         Box::new(ControlCharNormalizer),
+        Box::new(LowercaseNormalizer),
         Box::new(Classifier),
-        Box::new(PersianNormalizer),
     ]
 });
 
 /// List of [`Normalizer`]s used by [`Normalize::normalize`] that are considered lossy.
 pub static LOSSY_NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
     vec![
-        Box::new(LowercaseNormalizer),
         Box::new(QuoteNormalizer),
         Box::new(AeOeNormalizer),
         #[cfg(feature = "chinese-normalization")]
@@ -72,6 +71,7 @@ pub static LOSSY_NORMALIZERS: Lazy<Vec<Box<dyn Normalizer>>> = Lazy::new(|| {
         Box::new(JapaneseNormalizer),
         #[cfg(feature = "greek")]
         Box::new(GreekNormalizer),
+        Box::new(PersianNormalizer),
         Box::new(ArabicNormalizer),
         Box::new(NonspacingMarkNormalizer),
         #[cfg(feature = "vietnamese")]


### PR DESCRIPTION
Partially fixes (must be integrated into meilisearch next): https://github.com/meilisearch/meilisearch/issues/5851#issuecomment-3224325424

### Changes

- Put the lowercase normalizer before the classifier to make classification case-insensitive
- fix persian normalizer position