### PR TITLE
Fix: Prevent splitting of numbers and English words in Chinese text segmentation

### DIFF
--- a/charabia/src/segmenter/chinese.rs
+++ b/charabia/src/segmenter/chinese.rs
@@ -20,6 +20,9 @@ fn cut_for_search<'a>(s: &'a str) -> Box<dyn Iterator<Item = &'a str> + 'a> {
     if s.chars().count() <= 2 {
         return Box::new(std::iter::once(s));
     }
+    if s.chars().all(|c| c.is_alphanumeric()) {
+        return Box::new(std::iter::once(s));
+    }
     let mut subwords = Vec::new();
     let mut index = 0;
     loop {
@@ -333,4 +336,11 @@ mod test {
 
     // Macro that run several tests on the Segmenter.
     test_segmenter!(ChineseSegmenter, TEXT, SEGMENTED, TOKENIZED, Script::Cj, Language::Cmn);
+
+    #[test]
+    fn test_mix_number_and_letter() {
+        let seg = ChineseSegmenter;
+        let words: Vec<&str> = seg.segment_str("我从2025年开始学习Rust语言。").collect();
+        assert_eq!(words, vec!["我", "从", "2025", "年", "开始", "学习", "Rust", "语言", "。"]);
+    }
 }


### PR DESCRIPTION
# Pull Request

## Related issue

It’s very common for Chinese, numbers, and English to appear together in the same sentence. For example:
> 我从2025年开始学习Rust语言。
> 

In this sentence, charabia would segment it as:

`["我", "从", "2", "0", "2", "5", "年", "开始", "学习", "R", "u", "s", "t", "语言", "。"]`

Normally, numbers like **2025** and words like **Rust** should not be split apart.

If all numbers and English words are broken down into the most basic 10 digits and 26 letters, these numbers and words lose their meaning in search engines.

## What does this PR do?
- This PR prevents splitting of numbers and English words in Chinese text segmentation.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
