### PR TITLE
Change fallback for German tokenizer when not found in the word dictionary

### DIFF
--- a/charabia/src/segmenter/german.rs
+++ b/charabia/src/segmenter/german.rs
@@ -146,4 +146,7 @@ mod test {
     test_segmentation!("Basketball", &["Basket", "ball"], word16);
     test_segmentation!("Handball", &["Hand", "ball"], word17);
     test_segmentation!("Spikeball", &["Spike", "ball"], word18);
+    // Fallback when usual tokenization is not possible, no more bigrams allowed.
+    test_segmentation!("Feuchteschutz", &["Feuchte", "schutz"], word19);
+    test_segmentation!("insgesamt", &["ins", "gesamt"], word20);
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- It improves the German words segmentation. If a word is not in a dictionary it doesn't split it 2 by 2 anymore but takes all preceding characters into account.

Before: `"Feuchteschutz" -> ["Fe" "uc" "ht" "es, "ch", "utz"]`
After: `"Feuchteschutz" -> ["Feuchte", "schutz"]`

Before: `"insgesamt" -> ["in" "sg" "es" "amt"]`
After: `"insgesamt" -> ["ins", "gesamt"]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added German language segmentation test cases to validate fallback tokenization scenarios.

* **Chores**
  * Enhanced text segmentation logic to improve handling of character-level text processing and boundary detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->