### PR TITLE
Remove bors and use GitHub merge queue

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -21,7 +21,5 @@ sort-direction: 'ascending'
 replacers:
   - search: '/(?:and )?@dependabot-preview(?:\[bot\])?,?/g'
     replace: ''
-  - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
-    replace: ''
   - search: '/(?:and )?@meili-bot,?/g'
     replace: ''

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,7 @@ name: Rust
 
 on:
   pull_request:
-  push:
-    # trying and staging branches are for Bors config
-    branches:
-      - trying
-      - staging
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,16 +98,10 @@ Some notes on GitHub PRs:
 - The PR title should be accurate and descriptive of the changes. The title of the PR will be indeed automatically added to the next [release changelogs](https://github.com/meilisearch/charabia/releases/).
 - [Convert your PR as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request) if your changes are a work in progress: no one will review it until you pass your PR as ready for review.<br>
   The draft PRs are recommended when you want to show that you are working on something and make your work visible.
-- The branch related to the PR must be **up-to-date with `main`** before merging. Fortunately, this project uses [Bors](https://github.com/bors-ng/bors-ng) to automatically enforce this requirement without the PR author having to rebase manually.
 
 ## Release Process (for internal team only)
 
 Meilisearch tools follow the [Semantic Versioning Convention](https://semver.org/).
-
-### Automation to rebase and Merge the PRs <!-- omit in toc -->
-
-This project integrates a bot that helps us manage pull requests merging.<br>
-_[Read more about this](https://github.com/meilisearch/integration-guides/blob/main/resources/bors.md)._
 
 ### Automated changelogs <!-- omit in toc -->
 


### PR DESCRIPTION
Ruleset set up for the usage of GitHub merge queue ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow triggering mechanism for pull request handling.
  * Removed dependency-related automation from release draft generation.

* **Documentation**
  * Simplified contributing guidelines by removing outdated automation documentation.
  * Removed requirements for branch synchronization before submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->