### PR TITLE
Replace yanked core2 to make charabia installable again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ resolver = "2"
 members = ["charabia", "irg-kvariants"]
 default-members = ["charabia"]
 
+[patch.crates-io]
+core2 = { path = "core2-shim" }
+

--- a/core2-shim/Cargo.toml
+++ b/core2-shim/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "core2"
+version = "0.4.0"
+edition = "2021"
+description = "Local shim replacing the yanked core2 crate — re-exports std::io"
+
+[features]
+default = ["std"]
+std = []
+alloc = []

--- a/core2-shim/src/lib.rs
+++ b/core2-shim/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod io {
+    pub use std::io::*;
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes [#373](https://github.com/meilisearch/charabia/issues/373)

## What does this PR do?
- Replaces yanked `core2` dependency with minimal code
- This was written by Claude Code (Opus 4.6)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a local `core2` package shim to replace the standard crates.io dependency, with configurable feature flags for standard library and allocation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->