### PR TITLE
Fix script detection of halfwidth katakana and fullwidth forms

### DIFF
--- a/charabia/src/detection/chars.rs
+++ b/charabia/src/detection/chars.rs
@@ -26,6 +26,9 @@ pub(crate) fn is_latin(ch: char) -> bool {
         | '\u{2C60}'..='\u{2C7F}'
         | '\u{A720}'..='\u{A7FF}'
         | '\u{AB30}'..='\u{AB6F}'
+        // Fullwidth ASCII variants (digits, latin letters, punctuation) in the
+        // Halfwidth and Fullwidth Forms block.
+        | '\u{FF01}'..='\u{FF5E}'
     )
 }
 
@@ -104,7 +107,10 @@ pub(crate) fn is_hiragana(ch: char) -> bool {
 }
 
 pub(crate) fn is_katakana(ch: char) -> bool {
-    matches!(ch, '\u{30A0}'..='\u{30FF}')
+    // The second range covers the halfwidth katakana variants (middle dot, the
+    // halfwidth katakana letters, and the voiced/semi-voiced sound marks) in the
+    // Halfwidth and Fullwidth Forms block.
+    matches!(ch, '\u{30A0}'..='\u{30FF}' | '\u{FF65}'..='\u{FF9F}')
 }
 
 // Hangul is Korean Alphabet. Unicode ranges are taken from: https://en.wikipedia.org/wiki/Hangul
@@ -116,7 +122,10 @@ pub(crate) fn is_hangul(ch: char) -> bool {
         | '\u{3200}'..='\u{32FF}'
         | '\u{A960}'..='\u{A97F}'
         | '\u{D7B0}'..='\u{D7FF}'
-        | '\u{FF00}'..='\u{FFEF}'
+        // Halfwidth Hangul variants (filler and jamo). The rest of the Halfwidth
+        // and Fullwidth Forms block holds fullwidth ASCII and halfwidth katakana,
+        // which are not Hangul.
+        | '\u{FFA0}'..='\u{FFDC}'
     )
 }
 
@@ -191,6 +200,8 @@ mod tests {
         assert!(is_latin('č'));
         assert!(is_latin('š'));
         assert!(is_latin('Ĵ'));
+        assert!(is_latin('\u{FF21}')); // Fullwidth A.
+        assert!(is_latin('\u{FF10}')); // Fullwidth digit 0.
 
         assert!(!is_latin('ж'));
     }
@@ -230,6 +241,8 @@ mod tests {
     #[test]
     fn test_is_katakana() {
         assert!(is_katakana('カ'));
+        assert!(is_katakana('\u{FF76}')); // Halfwidth katakana ｶ.
+        assert!(is_katakana('\u{FF9E}')); // Halfwidth voiced sound mark.
         assert!(!is_katakana('f'));
     }
 
@@ -242,7 +255,10 @@ mod tests {
     #[test]
     fn test_is_hangul() {
         assert!(is_hangul('ᄁ'));
+        assert!(is_hangul('\u{FFA1}')); // Halfwidth hangul ﾡ.
         assert!(!is_hangul('t'));
+        assert!(!is_hangul('\u{FF76}')); // Halfwidth katakana ｶ is japanese.
+        assert!(!is_hangul('\u{FF21}')); // Fullwidth A is latin.
     }
 
     #[test]

--- a/charabia/src/detection/script_language.rs
+++ b/charabia/src/detection/script_language.rs
@@ -374,4 +374,18 @@ mod test {
         assert_eq!(Script::Cj.name(), "Mandarin");
         assert_eq!(Script::from_name("Mandarin"), Script::Cj);
     }
+
+    #[test]
+    fn script_from_halfwidth_and_fullwidth_forms() {
+        // Halfwidth katakana is japanese (Cj), fullwidth ASCII is latin, and
+        // only the halfwidth hangul range stays hangul.
+        assert_eq!(Script::from('\u{FF76}'), Script::Cj); // ｶ
+        assert_eq!(Script::from('\u{FF71}'), Script::Cj); // ｱ
+        assert_eq!(Script::from('\u{FF9D}'), Script::Cj); // ﾝ
+        assert_eq!(Script::from('\u{FF9E}'), Script::Cj); // voiced sound mark
+        assert_eq!(Script::from('\u{FF21}'), Script::Latin); // Ａ
+        assert_eq!(Script::from('\u{FF10}'), Script::Latin); // ０
+        assert_eq!(Script::from('\u{FFA1}'), Script::Hangul); // ﾡ
+        assert_eq!(Script::from('\u{AC00}'), Script::Hangul); // 가
+    }
 }


### PR DESCRIPTION
## Problem

`is_hangul` claims the entire Halfwidth and Fullwidth Forms block:

```rust
| '\u{FF00}'..='\u{FFEF}'
```

That block is three scripts mixed together:

- U+FF01..=FF5E: fullwidth ASCII (latin)
- U+FF65..=FF9F: halfwidth katakana (japanese)
- U+FFA0..=FFDC: halfwidth hangul (korean)

In `From<char> for Script`, `is_hangul` runs before `is_katakana`, so every halfwidth katakana and fullwidth ASCII character returns `Script::Hangul`. The segmenter then routes that text to the Korean pipeline. Halfwidth katakana is common in legacy and financial Japanese data, so those documents are segmented and normalized as Korean.

## Change

- `is_hangul`: narrow to U+FFA0..=FFDC (halfwidth hangul filler and jamo).
- `is_katakana`: add U+FF65..=FF9F (halfwidth katakana middle dot, letters, voiced and semi-voiced sound marks).
- `is_latin`: add U+FF01..=FF5E (fullwidth ASCII).

After the change:

```rust
Script::from('ｶ') -> Cj
Script::from('ｱ') -> Cj
Script::from('Ａ') -> Latin
Script::from('가') -> Hangul   // unchanged
Script::from('ﾡ') -> Hangul   // halfwidth hangul, unchanged
```

The over-broad range dates back to #60, which split Hangul out of `is_cjk`.

## Tests

Extended `test_is_latin`, `test_is_katakana`, and `test_is_hangul`, and added `script_from_halfwidth_and_fullwidth_forms`. Reverting the three range edits turns those four tests red.

Fixes #375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character classification for Unicode halfwidth and fullwidth forms, so Latin, Katakana, and Hangul text are recognized more accurately.
  * Fixed Hangul detection to exclude characters that belong to other scripts, such as fullwidth Latin and halfwidth Katakana variants.

* **Tests**
  * Added and updated coverage for script detection across representative halfwidth/fullwidth characters, including fullwidth letters and digits, halfwidth Katakana marks, and Hangul-specific characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->