### PR TITLE
 Reuse cached language

### DIFF
--- a/charabia/src/detection/mod.rs
+++ b/charabia/src/detection/mod.rs
@@ -29,8 +29,14 @@ impl<'o, 'al> StrDetection<'o, 'al> {
             Some(lang) => Some(lang),
             None => match self.allow_list {
                 Some([unique_language]) => Some(*unique_language),
-                None if Self::detect_script(inner) == Script::Latin => None,
-                _otherwise => Self::detect_lang(inner, self.allow_list),
+                None => {
+                    if self.script() == Script::Latin {
+                        None
+                    } else {
+                        Self::detect_lang(inner, None)
+                    }
+                }
+                allow_list => Self::detect_lang(inner, allow_list),
             },
         };
 

--- a/charabia/src/detection/mod.rs
+++ b/charabia/src/detection/mod.rs
@@ -29,14 +29,13 @@ impl<'o, 'al> StrDetection<'o, 'al> {
             Some(lang) => Some(lang),
             None => match self.allow_list {
                 Some([unique_language]) => Some(*unique_language),
-                None => {
+                allow_list => {
                     if self.script() == Script::Latin {
                         None
                     } else {
-                        Self::detect_lang(inner, None)
+                        Self::detect_lang(inner, allow_list)
                     }
-                }
-                allow_list => Self::detect_lang(inner, allow_list),
+                },
             },
         };
 


### PR DESCRIPTION
Hey folks

Trying charabia for an internal project where the tokenizer could be a bottleneck.

An LLM analysis found a free improvement to be made in language detection.

When processing Latin text, StrDetection::language() was detecting the script again instead of reusing the already cached result.

This PR reuses the cached script, avoiding one full scan of each Latin text segment without changing behavior. 

It's a modest 4% bench improvement, but it's an easy win.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection for Latin-script text when no language allowlist is provided.
  * Ensures a configured language allowlist is respected consistently during detection.
  * Enhances reliability by reusing previously detected script information to avoid conflicting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->