### PR TITLE
Make allow list API more flexible

### DIFF
--- a/charabia/src/detection/mod.rs
+++ b/charabia/src/detection/mod.rs
@@ -6,61 +6,75 @@ use whatlang::Detector;
 mod chars;
 mod script_language;
 
-pub struct StrDetection<'o, 'al> {
+pub struct StrDetection<'o, AllowList> {
     inner: &'o str,
     pub script: Option<Script>,
     pub language: Option<Language>,
-    allow_list: Option<&'al [Language]>,
+    allow_list: Option<AllowList>,
 }
 
-impl<'o, 'al> StrDetection<'o, 'al> {
-    pub fn new(inner: &'o str, allow_list: Option<&'al [Language]>) -> Self {
+impl<'o, AllowList> StrDetection<'o, AllowList> {
+    pub fn new(inner: &'o str, allow_list: Option<AllowList>) -> Self {
         Self { inner, script: None, language: None, allow_list }
     }
 
     pub fn script(&mut self) -> Script {
         let inner = self.inner;
-        *self.script.get_or_insert_with(|| Self::detect_script(inner))
+        *self.script.get_or_insert_with(|| detect_script(inner))
     }
 
-    pub fn language(&mut self) -> Option<Language> {
+    pub fn language<'lang, Lang>(&mut self) -> Option<Language>
+    where
+        AllowList: IntoIterator<Item = Lang> + Copy,
+        Lang: std::borrow::Borrow<Language>,
+    {
         let inner = self.inner;
         self.language = match self.language.take() {
             Some(lang) => Some(lang),
             None => match self.allow_list {
-                Some([unique_language]) => Some(*unique_language),
-                None if Self::detect_script(inner) == Script::Latin => None,
-                _otherwise => Self::detect_lang(inner, self.allow_list),
+                Some(ref allow_list) => {
+                    let mut iter = allow_list.into_iter();
+
+                    match iter.next() {
+                        Some(lang) if iter.next().is_none() => Some((*lang.borrow()).into()),
+                        _ => detect_lang(inner, Some(allow_list.into_iter())),
+                    }
+                }
+                None if detect_script(inner) == Script::Latin => None,
+                None => detect_lang::<<AllowList as IntoIterator>::IntoIter, Lang>(inner, None),
             },
         };
 
         self.language
     }
-
-    /// detect script with whatlang,
-    /// if no script is detected, return Script::Other
-    fn detect_script(text: &str) -> Script {
-        whatlang::detect_script(text).map(Script::from).unwrap_or_default()
-    }
-
-    /// detect lang with whatlang
-    /// if no language is detected, return Language::Other
-    fn detect_lang(text: &str, allow_list: Option<&[Language]>) -> Option<Language> {
-        let detector = allow_list
-            .map(|allow_list| allow_list.iter().map(|lang| (*lang).into()).collect())
-            .map(Detector::with_allowlist)
-            .unwrap_or_default();
-
-        detector.detect_lang(text).map(Language::from)
-    }
 }
 
-pub trait Detect<'o, 'al> {
-    fn detect(&'o self, allow_list: Option<&'al [Language]>) -> StrDetection<'o, 'al>;
+/// detect script with whatlang,
+/// if no script is detected, return Script::Other
+fn detect_script(text: &str) -> Script {
+    whatlang::detect_script(text).map(Script::from).unwrap_or_default()
 }
 
-impl<'o, 'al> Detect<'o, 'al> for &str {
-    fn detect(&'o self, allow_list: Option<&'al [Language]>) -> StrDetection<'o, 'al> {
+/// detect lang with whatlang
+/// if no language is detected, return Language::Other
+fn detect_lang<'a, I: Iterator<Item = L>, L: std::borrow::Borrow<Language>>(
+    text: &str,
+    allow_list: Option<I>,
+) -> Option<Language> {
+    let detector = allow_list
+        .map(|allow_list| allow_list.map(|lang| (*lang.borrow()).into()).collect())
+        .map(Detector::with_allowlist)
+        .unwrap_or_default();
+
+    detector.detect_lang(text).map(Language::from)
+}
+
+pub trait Detect<'o> {
+    fn detect<AllowList>(&'o self, allow_list: Option<AllowList>) -> StrDetection<'o, AllowList>;
+}
+
+impl<'o> Detect<'o> for &str {
+    fn detect<AllowList>(&'o self, allow_list: Option<AllowList>) -> StrDetection<'o, AllowList> {
         StrDetection::new(self, allow_list)
     }
 }

--- a/charabia/src/normalizer/mod.rs
+++ b/charabia/src/normalizer/mod.rs
@@ -88,12 +88,16 @@ pub(crate) const DEFAULT_NORMALIZER_OPTION: NormalizerOption = NormalizerOption 
 };
 
 /// Iterator over Normalized [`Token`]s.
-pub struct NormalizedTokenIter<'o, 'aho, 'lang, 'tb> {
-    token_iter: SegmentedTokenIter<'o, 'aho, 'lang>,
+pub struct NormalizedTokenIter<'o, 'aho, 'tb, AllowList> {
+    token_iter: SegmentedTokenIter<'o, 'aho, AllowList>,
     options: &'tb NormalizerOption<'tb>,
 }
 
-impl<'o> Iterator for NormalizedTokenIter<'o, '_, '_, '_> {
+impl<'o, 'lang, AllowList, Lang> Iterator for NormalizedTokenIter<'o, '_, '_, AllowList>
+where
+    AllowList: IntoIterator<Item = Lang> + Copy,
+    Lang: std::borrow::Borrow<crate::Language>,
+{
     type Item = Token<'o>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -239,14 +243,14 @@ impl From<String> for CharOrStr {
     }
 }
 
-impl<'o, 'aho, 'lang> SegmentedTokenIter<'o, 'aho, 'lang> {
+impl<'o, 'aho, AllowList> SegmentedTokenIter<'o, 'aho, AllowList> {
     /// Normalize [`Token`]s using all the compatible Normalizers.
     ///
     /// A Latin `Token` would not be normalized the same as a Chinese `Token`.
     pub fn normalize<'tb>(
         self,
         options: &'tb NormalizerOption<'tb>,
-    ) -> NormalizedTokenIter<'o, 'aho, 'lang, 'tb> {
+    ) -> NormalizedTokenIter<'o, 'aho, 'tb, AllowList> {
         NormalizedTokenIter { token_iter: self, options }
     }
 }

--- a/charabia/src/segmenter/mod.rs
+++ b/charabia/src/segmenter/mod.rs
@@ -97,13 +97,17 @@ pub static DEFAULT_SEPARATOR_AHO: LazyLock<AhoCorasick> = LazyLock::new(|| {
 });
 
 /// Iterator over segmented [`Token`]s.
-pub struct SegmentedTokenIter<'o, 'aho, 'lang> {
-    inner: SegmentedStrIter<'o, 'aho, 'lang>,
+pub struct SegmentedTokenIter<'o, 'aho, AllowList> {
+    inner: SegmentedStrIter<'o, 'aho, AllowList>,
     char_index: usize,
     byte_index: usize,
 }
 
-impl<'o> Iterator for SegmentedTokenIter<'o, '_, '_> {
+impl<'o, 'lang, AllowList, Lang> Iterator for SegmentedTokenIter<'o, '_, AllowList>
+where
+    AllowList: IntoIterator<Item = Lang> + Copy,
+    Lang: std::borrow::Borrow<crate::Language>,
+{
     type Item = Token<'o>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -127,30 +131,30 @@ impl<'o> Iterator for SegmentedTokenIter<'o, '_, '_> {
     }
 }
 
-impl<'o, 'aho, 'lang> From<SegmentedStrIter<'o, 'aho, 'lang>>
-    for SegmentedTokenIter<'o, 'aho, 'lang>
+impl<'o, 'aho, AllowList> From<SegmentedStrIter<'o, 'aho, AllowList>>
+    for SegmentedTokenIter<'o, 'aho, AllowList>
 {
-    fn from(segmented_str_iter: SegmentedStrIter<'o, 'aho, 'lang>) -> Self {
+    fn from(segmented_str_iter: SegmentedStrIter<'o, 'aho, AllowList>) -> Self {
         Self { inner: segmented_str_iter, char_index: 0, byte_index: 0 }
     }
 }
 
-pub struct SegmentedStrIter<'o, 'aho, 'lang> {
+pub struct SegmentedStrIter<'o, 'aho, AllowList> {
     inner: Box<dyn Iterator<Item = &'o str> + 'o>,
     current: Box<dyn Iterator<Item = &'o str> + 'o>,
     aho_iter: Option<AhoSegmentedStrIter<'o, 'aho>>,
     segmenter: &'static dyn Segmenter,
     aho: Option<&'aho AhoCorasick>,
-    allow_list: Option<&'lang [Language]>,
+    allow_list: Option<AllowList>,
     script: Script,
     language: Option<Language>,
 }
 
-impl<'o, 'aho, 'lang> SegmentedStrIter<'o, 'aho, 'lang> {
+impl<'o, 'aho, AllowList> SegmentedStrIter<'o, 'aho, AllowList> {
     pub fn new(
         original: &'o str,
         aho: Option<&'aho AhoCorasick>,
-        allow_list: Option<&'lang [Language]>,
+        allow_list: Option<AllowList>,
     ) -> Self {
         let mut current_script = Script::Other;
         let mut group_id = 0;
@@ -180,7 +184,11 @@ impl<'o, 'aho, 'lang> SegmentedStrIter<'o, 'aho, 'lang> {
     }
 }
 
-impl<'o> Iterator for SegmentedStrIter<'o, '_, '_> {
+impl<'o, 'lang, AllowList, Lang> Iterator for SegmentedStrIter<'o, '_, AllowList>
+where
+    AllowList: IntoIterator<Item = Lang> + Copy,
+    Lang: std::borrow::Borrow<Language>,
+{
     type Item = &'o str;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -277,7 +285,13 @@ enum MatchType {
 /// if no Script is detected or no segmenter corresponds to the Script,
 /// the function try to get the default segmenter in the map;
 /// if no default segmenter exists in the map return the library DEFAULT_SEGMENTER.
-fn segmenter<'b>(detector: &mut StrDetection) -> &'b dyn Segmenter {
+fn segmenter<'b, 'lang, AllowList, Lang>(
+    detector: &mut StrDetection<AllowList>,
+) -> &'b dyn Segmenter
+where
+    AllowList: IntoIterator<Item = Lang> + Copy,
+    Lang: std::borrow::Borrow<Language>,
+{
     let detected_script = detector.script();
     let mut filtered_segmenters =
         SEGMENTERS.iter().filter(|((script, _), _)| *script == detected_script);
@@ -352,16 +366,16 @@ pub trait Segment<'o> {
     /// assert_eq!(lemma, "quick");
     /// assert_eq!(kind, TokenKind::Unknown);
     /// ```
-    fn segment(&self) -> SegmentedTokenIter<'o, 'o, 'o> {
+    fn segment(&self) -> SegmentedTokenIter<'o, 'o, &'o [Language]> {
         self.segment_str().into()
     }
 
     /// Segments the provided text creating an Iterator over Tokens where you can specify an allowed list of languages to be used with a script.
-    fn segment_with_option<'aho, 'lang>(
+    fn segment_with_option<'aho, AllowList>(
         &self,
         aho: Option<&'aho AhoCorasick>,
-        allow_list: Option<&'lang [Language]>,
-    ) -> SegmentedTokenIter<'o, 'aho, 'lang> {
+        allow_list: Option<AllowList>,
+    ) -> SegmentedTokenIter<'o, 'aho, AllowList> {
         self.segment_str_with_option(aho, allow_list).into()
     }
 
@@ -380,25 +394,25 @@ pub trait Segment<'o> {
     /// assert_eq!(segments.next(), Some(" "));
     /// assert_eq!(segments.next(), Some("quick"));
     /// ```
-    fn segment_str(&self) -> SegmentedStrIter<'o, 'o, 'o> {
+    fn segment_str(&self) -> SegmentedStrIter<'o, 'o, &'o [Language]> {
         self.segment_str_with_option(None, None)
     }
 
     /// Segments the provided text creating an Iterator over `&str` where you can specify an allowed list of languages to be used with a script.
     ///
-    fn segment_str_with_option<'aho, 'lang>(
+    fn segment_str_with_option<'aho, AllowList>(
         &self,
         aho: Option<&'aho AhoCorasick>,
-        allow_list: Option<&'lang [Language]>,
-    ) -> SegmentedStrIter<'o, 'aho, 'lang>;
+        allow_list: Option<AllowList>,
+    ) -> SegmentedStrIter<'o, 'aho, AllowList>;
 }
 
 impl<'o> Segment<'o> for &'o str {
-    fn segment_str_with_option<'aho, 'lang>(
+    fn segment_str_with_option<'aho, AllowList>(
         &self,
         aho: Option<&'aho AhoCorasick>,
-        allow_list: Option<&'lang [Language]>,
-    ) -> SegmentedStrIter<'o, 'aho, 'lang> {
+        allow_list: Option<AllowList>,
+    ) -> SegmentedStrIter<'o, 'aho, AllowList> {
         SegmentedStrIter::new(self, aho, allow_list)
     }
 }

--- a/charabia/src/tokenizer.rs
+++ b/charabia/src/tokenizer.rs
@@ -10,12 +10,16 @@ use crate::separators::DEFAULT_SEPARATORS;
 use crate::Token;
 
 /// Iterator over tuples of [`&str`] (part of the original text) and [`Token`].
-pub struct ReconstructedTokenIter<'o, 'aho, 'lang, 'tb> {
-    token_iter: NormalizedTokenIter<'o, 'aho, 'lang, 'tb>,
+pub struct ReconstructedTokenIter<'o, 'aho, 'tb, AllowList> {
+    token_iter: NormalizedTokenIter<'o, 'aho, 'tb, AllowList>,
     original: &'o str,
 }
 
-impl<'o> Iterator for ReconstructedTokenIter<'o, '_, '_, '_> {
+impl<'o, 'lang, AllowList, Lang> Iterator for ReconstructedTokenIter<'o, '_, '_, AllowList>
+where
+    AllowList: IntoIterator<Item = Lang> + Copy,
+    Lang: std::borrow::Borrow<Language>,
+{
     type Item = (&'o str, Token<'o>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -53,7 +57,7 @@ pub trait Tokenize<'o> {
     /// assert_eq!(lemma, "quick");
     /// assert_eq!(kind, TokenKind::Word);
     /// ```
-    fn tokenize(&self) -> NormalizedTokenIter<'_, '_, '_, '_>;
+    fn tokenize(&self) -> NormalizedTokenIter<'_, '_, '_, &'_ [Language]>;
 
     /// Same as [`tokenize`] but attaches each [`Token`] to its corresponding portion of the original text.
     ///
@@ -81,15 +85,15 @@ pub trait Tokenize<'o> {
     /// assert_eq!(lemma, "quick");
     /// assert_eq!(kind, TokenKind::Word);
     /// ```
-    fn reconstruct(&self) -> ReconstructedTokenIter<'_, '_, '_, '_>;
+    fn reconstruct(&self) -> ReconstructedTokenIter<'_, '_, '_, &'_ [Language]>;
 }
 
 impl Tokenize<'_> for &str {
-    fn tokenize(&self) -> NormalizedTokenIter<'_, '_, '_, '_> {
+    fn tokenize(&self) -> NormalizedTokenIter<'_, '_, '_, &[Language]> {
         self.segment().normalize(&crate::normalizer::DEFAULT_NORMALIZER_OPTION)
     }
 
-    fn reconstruct(&self) -> ReconstructedTokenIter<'_, '_, '_, '_> {
+    fn reconstruct(&self) -> ReconstructedTokenIter<'_, '_, '_, &[Language]> {
         ReconstructedTokenIter { original: self, token_iter: self.tokenize() }
     }
 }
@@ -108,7 +112,10 @@ impl Tokenizer<'_> {
     ///
     /// The provided text is segmented creating tokens,
     /// then tokens are normalized and classified depending on the list of normalizers and classifiers in [`normalizer::NORMALIZERS`].
-    pub fn tokenize<'t, 'o>(&'t self, original: &'o str) -> NormalizedTokenIter<'o, 't, 't, 't> {
+    pub fn tokenize<'t, 'o>(
+        &'t self,
+        original: &'o str,
+    ) -> NormalizedTokenIter<'o, 't, 't, &'t [Language]> {
         original
             .segment_with_option(
                 self.segmenter_option.aho.as_ref(),
@@ -124,12 +131,42 @@ impl Tokenizer<'_> {
     ///
     /// # Arguments
     ///
-    /// * `allow_list` - a slice of [`Language`] to allow during autodetection.
-    pub fn tokenize_with_allow_list<'t, 'o, 'lang>(
+    /// * `allow_list` - a list of [`Language`]s to allow during autodetection.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use charabia::{TokenizerBuilder, Language};
+    ///
+    /// // text to tokenize.
+    /// let orig = "The quick (\"brown\") fox can't jump 32.3 feet, right? Brr, it's 29.3°F!";
+    ///
+    /// // create the tokenizer.
+    /// let mut builder = TokenizerBuilder::default();
+    /// let tokenizer = builder.build();
+    ///
+    /// // tokenize by passing a slice.
+    /// tokenizer.tokenize_with_allow_list(orig, Some(&[Language::Eng]));
+    ///
+    /// // tokenize by passing an optional.
+    /// let hint: Option<Language> = Some(Language::Eng);
+    /// tokenizer.tokenize_with_allow_list(orig, Some(&hint));
+    /// tokenizer.tokenize_with_allow_list(orig, Some(hint));
+    ///
+    /// // tokenize by passing a boxed slice.
+    /// let allow_list: Box<[Language]> = Box::from([Language::Eng]);
+    /// tokenizer.tokenize_with_allow_list(orig, Some(&allow_list));
+    /// tokenizer.tokenize_with_allow_list(orig, Some(allow_list));
+    /// ```
+    pub fn tokenize_with_allow_list<'t, 'o, 'lang, AllowList, Lang>(
         &'t self,
         original: &'o str,
-        allow_list: Option<&'lang [Language]>,
-    ) -> NormalizedTokenIter<'o, 't, 'lang, 't> {
+        allow_list: Option<AllowList>,
+    ) -> NormalizedTokenIter<'o, 't, 't, AllowList>
+    where
+        AllowList: IntoIterator<Item = Lang>,
+        Lang: std::borrow::Borrow<Language>,
+    {
         original
             .segment_with_option(self.segmenter_option.aho.as_ref(), allow_list)
             .normalize(&self.normalizer_option)
@@ -139,12 +176,15 @@ impl Tokenizer<'_> {
     pub fn reconstruct<'t, 'o>(
         &'t self,
         original: &'o str,
-    ) -> ReconstructedTokenIter<'o, 't, 't, 't> {
+    ) -> ReconstructedTokenIter<'o, 't, 't, &'t [Language]> {
         ReconstructedTokenIter { original, token_iter: self.tokenize(original) }
     }
 
     /// Segments the provided text creating an Iterator over [`Token`].
-    pub fn segment<'t, 'o>(&'t self, original: &'o str) -> SegmentedTokenIter<'o, 't, 't> {
+    pub fn segment<'t, 'o>(
+        &'t self,
+        original: &'o str,
+    ) -> SegmentedTokenIter<'o, 't, &'t [Language]> {
         original.segment_with_option(
             self.segmenter_option.aho.as_ref(),
             self.segmenter_option.allow_list,
@@ -152,7 +192,10 @@ impl Tokenizer<'_> {
     }
 
     /// Segments the provided text creating an Iterator over `&str`.
-    pub fn segment_str<'t, 'o>(&'t self, original: &'o str) -> SegmentedStrIter<'o, 't, 't> {
+    pub fn segment_str<'t, 'o>(
+        &'t self,
+        original: &'o str,
+    ) -> SegmentedStrIter<'o, 't, &'t [Language]> {
         original.segment_str_with_option(
             self.segmenter_option.aho.as_ref(),
             self.segmenter_option.allow_list,


### PR DESCRIPTION
Hey!

When implementing https://github.com/valeriansaliou/sonic/issues/375 I got slowed down because the `charabia` API was too restrictive regarding language allow lists. I had a `Option<charabia::Language>`, and your API forced me to give a `&[charabia::Language]`. I couldn’t use [`std::option::Option::as_slice`](https://doc.rust-lang.org/std/option/enum.Option.html#method.as_slice) because of lifetime issues, and I didn’t want it to impact all of my code, so I decided to fix the issue upstream.

Conceptually, what you want is to iterate over `charabia::Language`s. I made it so your API now accepts any `IntoIterator<Item = &Language> + Copy`, which adds support for `&Option<T>`, `&Box<[T]>`, etc. without breaking the current `&[T]` API.

I was hoping it could be a non-breaking change, but unfortunately the signature of `pub trait Tokenize` changed slightly which will break implementations. The fix is trivial though, it only consists of changing two `<'_, '_, '_, '_>` into `<'_, '_, '_, &'_ [Language]>`.

Although I doubt it’s used by a lot of people, as `&str` is likely the only type anyone expects to implement this helper trait, I wouldn’t be surprised if you chose to keep the API stable and dismiss this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible language allow-list support across detection, segmentation, normalization, and tokenization.
  * Allow-lists can now be provided through multiple compatible collection types.
  * Existing convenience methods continue to use the default language list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->