### PR TITLE
Bump dependencies and bump the version to v0.10.0

### DIFF
--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charabia"
-version = "0.9.9"
+version = "0.10.0"
 license = "MIT"
 authors = ["Many <many@meilisearch.com>"]
 edition = "2021"

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -17,7 +17,7 @@ csv = "1.3.1"
 either = "1.15.0"
 finl_unicode = { version = "1.3.0", optional = true }
 fst = "0.4"
-jieba-rs = { version = "0.8.1", optional = true }
+jieba-rs = { version = "0.10.3", optional = true }
 serde = "1.0.223"
 slice-group-by = "0.3.1"
 whatlang = "0.16.4"

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -20,12 +20,12 @@ fst = "0.4"
 jieba-rs = { version = "0.10.3", optional = true }
 serde = "1.0.229"
 slice-group-by = "0.3.1"
-whatlang = "0.16.4"
-lindera = { version = "0.43.3", default-features = false, optional = true }
-pinyin = { version = "0.10", default-features = false, features = [
+whatlang = "0.18.0"
+lindera = { version = "5.1.0", default-features = false, optional = true }
+pinyin = { version = "0.11", default-features = false, features = [
     "with_tone",
 ], optional = true }
-wana_kana = { version = "4.0.0", optional = true }
+wana_kana = { version = "5.0.0", optional = true }
 unicode-normalization = "0.1.25"
 irg-kvariants = { path = "../irg-kvariants", version = "=0.1.1" }
 
@@ -54,13 +54,13 @@ chinese-normalization-pinyin = ["dep:pinyin", "chinese-normalization"]
 hebrew = []
 
 # allow japanese specialized tokenization
-japanese = ["japanese-segmentation-unidic", "japanese-transliteration"]
-japanese-segmentation-ipadic = ["lindera/ipadic", "lindera/compress"]
-japanese-segmentation-unidic = ["lindera/unidic", "lindera/compress"]
+japanese = ["japanese-segmentation-unidic", "japanese-transliteration", "lindera/embed-unidic"]
+japanese-segmentation-ipadic = ["lindera/lindera-ipadic", "lindera/embed-ipadic"]
+japanese-segmentation-unidic = ["lindera/lindera-unidic", "lindera/embed-unidic"]
 japanese-transliteration = ["dep:wana_kana"]
 
 # allow korean specialized tokenization
-korean = ["lindera/ko-dic", "lindera/compress"]
+korean = ["lindera/lindera-ko-dic", "lindera/embed-ko-dic"]
 
 # allow thai specialized tokenization
 thai = []
@@ -89,7 +89,7 @@ turkish = []
 german-segmentation = []
 
 [dev-dependencies]
-criterion = "0.7"
+criterion = "0.8"
 quickcheck = "1"
 quickcheck_macros = "1"
 mimalloc = "0.1.52"

--- a/charabia/Cargo.toml
+++ b/charabia/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["text-processing"]
 exclude = ["dictionaries/txt/thai/words.txt"]
 
 [dependencies]
-aho-corasick = "1.1.3"
-csv = "1.3.1"
-either = "1.15.0"
-finl_unicode = { version = "1.3.0", optional = true }
+aho-corasick = "1.1.5"
+csv = "1.4.0"
+either = "1.17.0"
+finl_unicode = { version = "1.4.0", optional = true }
 fst = "0.4"
 jieba-rs = { version = "0.10.3", optional = true }
-serde = "1.0.223"
+serde = "1.0.229"
 slice-group-by = "0.3.1"
 whatlang = "0.16.4"
 lindera = { version = "0.43.3", default-features = false, optional = true }
@@ -26,7 +26,7 @@ pinyin = { version = "0.10", default-features = false, features = [
     "with_tone",
 ], optional = true }
 wana_kana = { version = "4.0.0", optional = true }
-unicode-normalization = "0.1.24"
+unicode-normalization = "0.1.25"
 irg-kvariants = { path = "../irg-kvariants", version = "=0.1.1" }
 
 [features]
@@ -92,7 +92,7 @@ german-segmentation = []
 criterion = "0.7"
 quickcheck = "1"
 quickcheck_macros = "1"
-mimalloc = "0.1.48"
+mimalloc = "0.1.52"
 
 [[bench]]
 name = "bench"

--- a/charabia/src/detection/script_language.rs
+++ b/charabia/src/detection/script_language.rs
@@ -117,7 +117,8 @@ make_language! {
     Slk,
     Cat,
     Tgl,
-    Hye
+    Hye,
+    Cym
 }
 
 macro_rules! make_script {

--- a/charabia/src/segmenter/chinese.rs
+++ b/charabia/src/segmenter/chinese.rs
@@ -54,7 +54,7 @@ impl Segmenter for ChineseSegmenter {
         let segmented: Vec<&str> = JIEBA
             .cut(to_segment, false) // disable Hidden Markov Models.
             .into_iter()
-            .flat_map(|x| cut_for_search(x))
+            .flat_map(|x| cut_for_search(x.word))
             .collect();
         Box::new(segmented.into_iter())
     }

--- a/charabia/src/segmenter/japanese.rs
+++ b/charabia/src/segmenter/japanese.rs
@@ -1,11 +1,9 @@
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
-use lindera::dictionary::{load_dictionary_from_kind, DictionaryKind};
+use lindera::dictionary::{load_embedded_dictionary, DictionaryKind};
 use lindera::mode::{Mode, Penalty};
 use lindera::segmenter::Segmenter as LinderaSegmenter;
-use lindera::tokenizer::Tokenizer;
-#[cfg(feature = "japanese-segmentation-ipadic")]
-use lindera::Penalty;
 
 use crate::segmenter::Segmenter;
 
@@ -14,29 +12,22 @@ use crate::segmenter::Segmenter;
 /// This Segmenter uses lindera internally to segment the provided text.
 pub struct JapaneseSegmenter;
 
-static LINDERA: LazyLock<Tokenizer> = LazyLock::new(|| {
+static LINDERA: LazyLock<LinderaSegmenter> = LazyLock::new(|| {
     #[cfg(all(feature = "japanese-segmentation-ipadic", feature = "japanese-segmentation-unidic"))]
     compile_error!("Feature japanese-segmentation-ipadic and japanese-segmentation-unidic are mutually exclusive and cannot be enabled together");
 
     #[cfg(feature = "japanese-segmentation-ipadic")]
-    {
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
-        let segmenter =
-            LinderaSegmenter::new(Mode::Decompose(Penalty::default()), dictionary, None);
-        Tokenizer::new(segmenter)
-    }
+    let dictionary_kind = DictionaryKind::IPADIC;
     #[cfg(feature = "japanese-segmentation-unidic")]
-    {
-        let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
-        let segmenter =
-            LinderaSegmenter::new(Mode::Decompose(Penalty::default()), dictionary, None);
-        Tokenizer::new(segmenter)
-    }
+    let dictionary_kind = DictionaryKind::UniDic;
+
+    let dictionary = load_embedded_dictionary(dictionary_kind).unwrap();
+    LinderaSegmenter::new(Mode::Decompose(Penalty::default()), dictionary, None)
 });
 
 impl Segmenter for JapaneseSegmenter {
     fn segment_str<'o>(&self, to_segment: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
-        let tokens = LINDERA.tokenize(to_segment).unwrap();
+        let tokens = LINDERA.segment(Cow::Borrowed(to_segment)).unwrap();
 
         let result: Vec<&'o str> = tokens
             .into_iter()

--- a/charabia/src/segmenter/korean.rs
+++ b/charabia/src/segmenter/korean.rs
@@ -1,9 +1,9 @@
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
-use lindera::dictionary::{load_dictionary_from_kind, DictionaryKind};
+use lindera::dictionary::{load_embedded_dictionary, DictionaryKind};
 use lindera::mode::{Mode, Penalty};
 use lindera::segmenter::Segmenter as LinderaSegmenter;
-use lindera::tokenizer::Tokenizer;
 
 use crate::segmenter::Segmenter;
 
@@ -12,15 +12,14 @@ use crate::segmenter::Segmenter;
 /// This Segmenter uses lindera internally to segment the provided text.
 pub struct KoreanSegmenter;
 
-static LINDERA: LazyLock<Tokenizer> = LazyLock::new(|| {
-    let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
-    let segmenter = LinderaSegmenter::new(Mode::Decompose(Penalty::default()), dictionary, None);
-    Tokenizer::new(segmenter)
+static LINDERA: LazyLock<LinderaSegmenter> = LazyLock::new(|| {
+    let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
+    LinderaSegmenter::new(Mode::Decompose(Penalty::default()), dictionary, None)
 });
 
 impl Segmenter for KoreanSegmenter {
     fn segment_str<'o>(&self, to_segment: &'o str) -> Box<dyn Iterator<Item = &'o str> + 'o> {
-        let tokens = LINDERA.tokenize(to_segment).unwrap();
+        let tokens = LINDERA.segment(Cow::Borrowed(to_segment)).unwrap();
 
         let result: Vec<&'o str> = tokens
             .into_iter()

--- a/irg-kvariants/Cargo.toml
+++ b/irg-kvariants/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/meilisearch/charabia"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-csv = "1.3.1"
-once_cell = "1.21.3"
-serde = { version = "1.0.223", features = ["derive"] }
+csv = "1.4.0"
+once_cell = "1.21.4"
+serde = { version = "1.0.229", features = ["derive"] }
 
 [build-dependencies]
-csv = "1.3.1"
-serde = { version = "1.0.223", features = ["derive"] }
+csv = "1.4.0"
+serde = { version = "1.0.229", features = ["derive"] }


### PR DESCRIPTION
This PR bumps jieba, lindera, rand and bumps the version to v0.10.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Welsh language detection support.
  - Improved Chinese, Japanese, and Korean text segmentation.
  - Japanese and Korean segmentation now use embedded dictionaries for more consistent processing.

- **Bug Fixes**
  - Corrected Chinese search-token handling to improve segmentation results.

- **Maintenance**
  - Updated internal dependency versions and language-processing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->