### PR TITLE
Normalize Arabic and Persian Kaf/Yeh to a single canonical form

### DIFF
--- a/charabia/src/normalizer/arabic.rs
+++ b/charabia/src/normalizer/arabic.rs
@@ -6,7 +6,8 @@ use crate::{Script, Token};
 /// Arabic text should be normalized by:
 /// - removing the arabic Tatweel ('ـ') characters.
 /// - normalizing the arabic Alef 'أ','إ','آ','ٱ' to 'ا'
-/// - normalizing the arabic Yeh 'ى' to 'ي'
+/// - normalizing the Persian Yeh and arabic Yeh(Alef Maksoora) 'ى' to 'ي'
+/// - Normalizing the Persian Kaf 'ک' to 'ك'
 /// - Normalizing the arabic Taa Marbuta 'ة' to 'ه'
 ///   https://en.wikipedia.org/wiki/Arabic_alphabet
 ///   https://en.wikipedia.org/wiki/Kashida
@@ -28,14 +29,15 @@ fn normalize_arabic_char(c: char) -> Option<CharOrStr> {
     match c {
         'ـ' => None,
         'أ' | 'إ' | 'آ' | 'ٱ' => Some('ا'.into()), // All Alef variants to Alef
-        'ى' => Some('ي'.into()),
+        'ی' | 'ى' => Some('ي'.into()),       // Alef Maksoora and Persian Yeh to Arabic Yeh
         'ة' => Some('ه'.into()),
+        'ک' => Some('ك'.into()), // Persian Kaf to Arabic Kaf
         _ => Some(c.into()),
     }
 }
 
 fn is_shoud_normalize(c: char) -> bool {
-    matches!(c, 'ـ' | 'أ' | 'إ' | 'آ' | 'ٱ' | 'ى' | 'ة')
+    matches!(c, 'ـ' | 'أ' | 'إ' | 'آ' | 'ٱ' | 'ى' | 'ی' | 'ک' | 'ة')
 }
 
 #[cfg(test)]

--- a/charabia/src/normalizer/persian.rs
+++ b/charabia/src/normalizer/persian.rs
@@ -5,8 +5,8 @@ use crate::{Script, Token};
 /// A global [`Normalizer`] for the Persian language.
 /// Persian alphabet: ا,ب,پ,ت,ث,ج,چ,ح,خ,د,ذ,ر,ز,ژ,س,ش,ص,ض,ط,ظ,ع,غ,ف,ق,ک,گ,ل,م,ن,و,ه,ی
 /// Persian text should be normalized by:
-/// - Normalizing the Persian Yeh 'ی', 'ي', 'ى', 'ۀ' to 'ی'
-/// - Normalizing the Persian Kaf 'ک' and 'ك' to 'ک'
+/// - Normalizing the Persian Yeh 'ي', 'ى', 'ۀ' to 'ی'
+/// - Normalizing the Arabic Kaf 'ك' to 'ک'
 /// - Normalizing the Persian numbers '۰'-'۹' to '0'-'9'
 /// - Removing diacritics '◌َ' to '◌ْ' (Fatha to Sukun)
 /// - Normalizing Rial sign '﷼' to 'RIAL'
@@ -28,10 +28,10 @@ impl CharNormalizer for PersianNormalizer {
 
 fn normalize_persian_char(c: char) -> Option<CharOrStr> {
     match c {
-        // Arabic Yeh, Persian Yeh, Yeh without dots, Yeh with Hamza to Persian Yeh
-        'ي' | 'ی' | 'ى' | 'ۀ' => Some('ی'.into()),
-        // Arabic Kaf and Persian Kaf to Persian Kaf
-        'ك' | 'ک' => Some('ک'.into()),
+        // Arabic Yeh, Yeh without dots, Yeh with Hamza to Persian Yeh
+        'ي' | 'ى' | 'ۀ' => Some('ی'.into()),
+        // Arabic Kaf to Persian Kaf
+        'ك' => Some('ک'.into()),
         // Persian digits to ASCII digits
         '۰' => Some('0'.into()),
         '۱' => Some('1'.into()),
@@ -58,8 +58,8 @@ fn normalize_persian_char(c: char) -> Option<CharOrStr> {
 fn is_should_normalize(c: char) -> bool {
     matches!(
         c,
-        'ي' | 'ی' | 'ى' | 'ۀ' | // Yeh variants
-        'ك' | 'ک' | // Kaf variants
+        'ي' | 'ى' | 'ۀ' | // Yeh variants
+        'ك' | // Arabic Kaf
         '۰'
             ..='۹' | // Persian digits
         '،' | '؟' | // Persian/Arabic punctuation
@@ -305,7 +305,7 @@ mod test {
     fn normalized_tokens() -> Vec<Token<'static>> {
         vec![
             Token {
-                lemma: Owned("علی".to_string()),
+                lemma: Owned("علي".to_string()),
                 char_end: 3,
                 byte_end: 6,
                 script: Script::Arabic,
@@ -315,7 +315,7 @@ mod test {
                 ..Default::default()
             },
             Token {
-                lemma: Owned("کتاب".to_string()),
+                lemma: Owned("كتاب".to_string()),
                 char_end: 4,
                 byte_end: 8,
                 script: Script::Arabic,
@@ -335,7 +335,7 @@ mod test {
                 ..Default::default()
             },
             Token {
-                lemma: Owned("کیک 123 یک کتاب".to_string()),
+                lemma: Owned("كيك 123 يك كتاب".to_string()),
                 char_end: 13,
                 byte_end: 24,
                 script: Script::Arabic,
@@ -344,19 +344,19 @@ mod test {
                 char_map: Some(vec![
                     (2, 2),
                     (2, 2),
-                    (2, 2), // کیک
+                    (2, 2), // كيك
                     (1, 1), // space
                     (2, 1),
                     (2, 1),
                     (2, 1), // ۱۲۳ (Persian digits, normalized to ASCII)
                     (1, 1), // space
                     (2, 2),
-                    (2, 2), // یک
+                    (2, 2), // يك
                     (1, 1), // space
                     (2, 2),
                     (2, 2),
                     (2, 2),
-                    (2, 2), // کتاب
+                    (2, 2), // كتاب
                 ]),
                 ..Default::default()
             },
@@ -389,7 +389,7 @@ mod test {
             },
             Token {
                 lemma: Owned(
-                    "قنات قصبه شهر گناباد عمیقترین و قدیمیترین کاریز جهان است.".to_string(),
+                    "قنات قصبه شهر گناباد عميقترين و قديميترين كاريز جهان است.".to_string(),
                 ),
                 char_end: 56,
                 byte_end: 112,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #377 

Persian normalizer maps arabic and persian Kaf/Yeh to persian Kaf/Yeh but arabic normalizer which also runs on persian text(because script=arabic), maps only arabic Kaf to arabic Kaf.

persian.rs: 

1. Arabic Yeh, Persian Yeh, Yeh without dots, Yeh with Hamza to Persian Yeh
2. Arabic Kaf and Persian Kaf to Persian Kaf

```
'ي' | 'ی' | 'ى' | 'ۀ' => Some('ی'.into()),
'ك' | 'ک' => Some('ک'.into()),
```

arabic.rs

1. Arabic Yeh to Arabic Yeh

```
'ى' => Some('ي'.into())
```

Consequence of this is that some of the normalized tokens will have persian Kaf/Yeh in them and some will have arabic Kaf/Yeh and hence searching with arabic Kaf matches only the documents that have arabic Kaf in the normalized tokens

## What does this PR do?

Now arabic normalizer also folds Kaf and Yeh to arabic Kaf/Yeh, thus overriding persian folding and therefore searching with arabic or persian Kaf/Yeh doesnt matter because both the query and lookedup tokens are now same

I used LLM to understand the codepoints of similar looking characters in arabic and persian

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arabic and Persian text normalization for Yeh and Kaf character variants.
  * Arabic variants are now consistently converted to their standard forms.
  * Persian Yeh and Kaf characters are preserved correctly during Persian text processing.
  * Arabic Alef Maksura is normalized consistently with Arabic Yeh.
  * Updated behavior maintains existing digit normalization and other character mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->